### PR TITLE
プロジェクト設定の更新と新規ファイルの追加

### DIFF
--- a/Engine/GameEngine.vcxproj
+++ b/Engine/GameEngine.vcxproj
@@ -120,7 +120,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
 </Command>
     </PostBuildEvent>
     <Lib>
-      <AdditionalLibraryDirectories>$(ProjectDir)externals\assimp\include\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)externals\assimp\lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>assimp-vc143-mt.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -261,6 +261,7 @@
     <ClCompile Include="Engine\Utility\Time.cpp">
       <Filter>Engine\Utility</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\eScene\SampleScene.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Engine\Audio\Audio.h">
@@ -440,6 +441,7 @@
     <ClInclude Include="Engine\Utility\Time.h">
       <Filter>Engine\Utility</Filter>
     </ClInclude>
+    <ClInclude Include="Engine\eScene\SampleScene.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Shader\LineDrawer.hlsli">

--- a/Sample/SampleProject.vcxproj
+++ b/Sample/SampleProject.vcxproj
@@ -76,6 +76,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\Engine\externals\assimp\include;$(ProjectDir)..\Engine\externals\DirectXTex;$(ProjectDir)..\Engine\externals\nlohmann;$(ProjectDir)..\Engine\externals\imgui;$(ProjectDir)..\Engine\Engine\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
`GameEngine.vcxproj` において、`PostBuildEvent` の `Command` セクションが変更され、`dxil.dll` のコピーコマンドが追加されました。また、`Lib` セクションで `AdditionalLibraryDirectories` のパスが `assimp\include` から `assimp\lib` に変更されました。

`GameEngine.vcxproj.filters` に `Engine\eScene\SampleScene.cpp` の `ClCompile` エントリと `Engine\eScene\SampleScene.h` の `ClInclude` エントリが追加されました。

`SampleProject.vcxproj` の `ClCompile` セクションに `LanguageStandard` が追加され、C++20 標準が指定されました。