### PR TITLE
デバッグ用 ImGui 呼び出しの整理と引数の削除

### DIFF
--- a/Engine/Features/Model/AnimationModel.cpp
+++ b/Engine/Features/Model/AnimationModel.cpp
@@ -16,9 +16,6 @@ void AnimationModel::Initialize(const std::string& _filePath)
 
 void AnimationModel::Update()
 {
-#ifdef _DEBUG
-    //ImGui();
-#endif // _DEBUG
 
 
     model_->Update(gameTime_->GetChannel(timeChannel).GetDeltaTime<float>());

--- a/Engine/Features/Model/AnimationModel.h
+++ b/Engine/Features/Model/AnimationModel.h
@@ -47,6 +47,9 @@ public:
     bool useQuaternion_ = false;
 
 
+#ifdef _DEBUG
+    void ImGui();
+#endif // _DEBUG
 private:
 
     WorldTransform worldTransform_;
@@ -56,8 +59,5 @@ private:
     std::string timeChannel = "default";
     GameTime* gameTime_ = nullptr;
 
-#ifdef _DEBUG
-    void ImGui();
-#endif // _DEBUG
 
 };

--- a/Engine/Features/Model/ObjectModel.cpp
+++ b/Engine/Features/Model/ObjectModel.cpp
@@ -19,12 +19,8 @@ void ObjectModel::Initialize(const std::string& _filePath, const std::string& _n
 
 }
 
-void ObjectModel::Update(const bool _showImgui)
+void ObjectModel::Update()
 {
-#ifdef _DEBUG
-    //if(_showImgui)
-        //ImGui();
-#endif // _DEBUG
     worldTransform_.transform_ = translate_;
     worldTransform_.scale_ = scale_;
     if (useQuaternion_)

--- a/Engine/Features/Model/ObjectModel.h
+++ b/Engine/Features/Model/ObjectModel.h
@@ -13,7 +13,7 @@ public:
     ~ObjectModel() = default;
 
     void Initialize(const std::string& _filePath, const std::string& _name="");
-    void Update(const bool _showImgui = true);
+    void Update();
     void Draw(const Camera* _camera ,const Vector4& _color);
     void Draw(const Camera* _camera, uint32_t _textureHandle, const Vector4& _color);
     void UseQuaternion(bool _use) { useQuaternion_ = _use; }
@@ -38,6 +38,9 @@ public:
     bool useQuaternion_ = false;
 
 
+#ifdef _DEBUG
+    void ImGui();
+#endif // _DEBUG
 
 
 private:
@@ -47,9 +50,6 @@ private:
     Model* model_ = nullptr;
     std::string name_ = "";
 
-#ifdef _DEBUG
-    void ImGui();
-#endif // _DEBUG
 
 
 };


### PR DESCRIPTION
`AnimationModel.cpp` の `Update` メソッドから `#ifdef _DEBUG` 内の `ImGui()` 呼び出しを削除し、`AnimationModel.h` の `public` セクションに `void ImGui();` メソッドを追加しました。また、`private` セクションから同じ `#ifdef _DEBUG` ブロックを削除しました。

`ObjectModel.cpp` の `Update` メソッドから `#ifdef _DEBUG` 内の `ImGui()` 呼び出しと引数 `_showImgui` を削除し、`ObjectModel.h` の `public` セクションで `Update` メソッドの引数 `_showImgui` を削除しました。さらに、`public` セクションに `void ImGui();` メソッドを追加し、`private` セクションから同じ `#ifdef _DEBUG` ブロックを削除しました。