### PR TITLE
Add ShowDebugWindow method for debug mode in SceneFactory

### DIFF
--- a/Sample/SceneFactory.cpp
+++ b/Sample/SceneFactory.cpp
@@ -18,3 +18,24 @@ std::unique_ptr<BaseScene> SceneFactory::CreateScene(const std::string& _name)
 
     return nullptr;
 }
+
+std::string SceneFactory::ShowDebugWindow()
+{
+#ifdef _DEBUG
+
+    ImGui::SeparatorText("Scene Factory");
+
+    if (ImGui::Button("Sample"))
+    {
+        return "Sample";
+    }
+    if (ImGui::Button("ParticleTest"))
+    {
+        return "ParticleTest";
+    }
+
+
+#endif // _DEBUG
+    return "";
+
+}

--- a/Sample/SceneFactory.h
+++ b/Sample/SceneFactory.h
@@ -6,4 +6,7 @@ class SceneFactory : public ISceneFactory
 {
 public:
     std::unique_ptr<BaseScene> CreateScene(const std::string& _name) override;
+
+    std::string ShowDebugWindow() override;
+
 };


### PR DESCRIPTION
SceneFactory.cppにShowDebugWindowメソッドを追加しました。このメソッドは、デバッグモード（_DEBUGが定義されている場合）でImGuiを使用してデバッグウィンドウを表示し、ボタンが押された場合に対応するシーン名を返します。デバッグモードでない場合は空の文字列を返します。 SceneFactory.hにShowDebugWindowメソッドの宣言を追加しました。