### PR TITLE
アニメーションの読み込みと補間処理の追加

### DIFF
--- a/Engine/Features/Model/Animation/ModelAnimation.h
+++ b/Engine/Features/Model/Animation/ModelAnimation.h
@@ -25,6 +25,8 @@ public:
     void Draw();
 
     void ReadAnimation(const aiAnimation* _animation);
+    void ReadSampler(const std::string& _filepath);
+
     void ToIdle(float _timeToIdle);
 
     void SetLoop(bool _loop) { isLoop_ = _loop; }
@@ -52,6 +54,7 @@ private:
         AnimationCurve<Vector3> translate;
         AnimationCurve<Quaternion> rotation;
         AnimationCurve<Vector3> scale;
+        std::string interpolation;
     };
     struct Animation
     {
@@ -59,9 +62,23 @@ private:
         std::map<std::string, NodeAnimation> nodeAnimations;
     };
 
+
     Animation animation_;
     Matrix4x4 localMatrix_;
     float animetionTimer_ = 0.0f;
+
+
+    struct Sampler
+    {
+        uint32_t input;
+        uint32_t output;
+        std::string interpolation;
+    };
+
+    std::vector<Sampler> samplers_;
+    // チャンネルとサンプラーの対応
+    std::map<uint32_t, uint32_t> channelToSampler_;
+
 
     bool isLoop_ = false;
     bool isPlaying_ = false;
@@ -70,7 +87,10 @@ private:
     // idle状態になる前のアニメーションの状態
     QuaternionTransform beforeIdleTransform_ = {};
 
-    Vector3 CalculateValue(const AnimationCurve<Vector3>& _curve, float _time);
-    Quaternion CalculateValue(const AnimationCurve<Quaternion>& _curve, float _time);
+    Vector3 CalculateValue_Linear(const AnimationCurve<Vector3>& _curve, float _time);
+    Quaternion CalculateValue_Linear(const AnimationCurve<Quaternion>& _curve, float _time);
+
+    Vector3 CalculateValue_Step(const AnimationCurve<Vector3>& _curve, float _time);
+    Quaternion CalculateValue_Step(const AnimationCurve<Quaternion>& _curve, float _time);
 
 };

--- a/Engine/Features/Model/AnimationModel.cpp
+++ b/Engine/Features/Model/AnimationModel.cpp
@@ -16,8 +16,6 @@ void AnimationModel::Initialize(const std::string& _filePath)
 
 void AnimationModel::Update()
 {
-
-
     model_->Update(gameTime_->GetChannel(timeChannel).GetDeltaTime<float>());
 
     worldTransform_.transform_ = translate_;

--- a/Engine/Features/Model/AnimationModel.h
+++ b/Engine/Features/Model/AnimationModel.h
@@ -32,6 +32,8 @@ public:
 
     const WorldTransform* GetWorldTransform() { return &worldTransform_; }
 
+    void LoadAnimation(const std::string& _filePath) { model_->LoadAnimation(_filePath); }
+
     UVTransform& GetUVTransform(uint32_t _index = 0) { return model_->GetUVTransform(_index); }
     void SetParent(const WorldTransform* _parent) { worldTransform_.parent_ = _parent; }
     void SetModel(const std::string& _filePath) { model_ = Model::CreateFromObj(_filePath); }

--- a/Engine/Features/Model/Model.h
+++ b/Engine/Features/Model/Model.h
@@ -45,6 +45,8 @@ public:
     void StopAnimation() { currentAnimation_ = nullptr; }
     void ToIdle(float _timeToIdle);
 
+    void LoadAnimation(const std::string& _filePath);
+
     UVTransform& GetUVTransform(uint32_t _index = 0) { return material_[_index]->GetUVTransform(); }
 
     Mesh* GetMeshPtr() { return mesh_[0].get(); }
@@ -78,7 +80,7 @@ private:
     void LoadFile(const std::string& _filepath);
     void LoadMesh(const aiScene* _scene);
     void LoadMaterial(const aiScene* _scene);
-    void LoadAnimation(const aiScene* _scene);
+    void LoadAnimation(const aiScene* _scene, const std::string& _filepath);
     void LoadNode(const aiScene* _scene);
     void CreateSkeleton();
     void CreateSkinCluster(const aiMesh* _mesh);


### PR DESCRIPTION
`ModelAnimation.cpp` に `JsonLoader.h` と `fstream` のインクルードを追加。`ModelAnimation::Update` メソッドに補間処理の条件分岐を追加し、`LINEAR`、`STEP`、`CUBICSPLINE` の各補間方法に対応。`ModelAnimation::ReadAnimation` メソッドで `channelIndex` と `keyframeIndex` の型を `int32_t` に変更し、サンプラーの読み込みと補間方法の設定を追加。`ModelAnimation::ReadSampler` メソッドを新規追加し、JSON ファイルからサンプラー情報を読み込む処理を実装。`ModelAnimation::CalculateValue` メソッドを `CalculateValue_Linear` に名前変更し、`CalculateValue_Step` メソッドを追加。`ModelAnimation.h` に `ReadSampler` メソッドと `Sampler` 構造体を追加し、`NodeAnimation` 構造体に `interpolation` メンバを追加。`CalculateValue_Linear` と `CalculateValue_Step` メソッドを追加。`AnimationModel.cpp` の `Initialize` メソッドから `Update` メソッドの呼び出しを削除。`AnimationModel.h` に `LoadAnimation` メソッドを追加。`Model.cpp` に `assimp/Importer.hpp` のインクルードを追加し、`LoadAnimation` メソッドを新規追加。`Model::LoadFile` メソッドで `LoadAnimation` メソッドの呼び出しをファイルパスを引数に取るように変更。`Model::LoadMesh` メソッドで頂点の位置と法線の座標系を変更。`Model::LoadAnimation` メソッドでアニメーション名が空の場合にデフォルト名を設定する処理とサンプラーの読み込みを追加。`Model.h` に `LoadAnimation` メソッドを追加。