### PR TITLE
アニメーションリセット機能の追加と型の修正

### DIFF
--- a/Engine/Features/Collision/Shapes.h
+++ b/Engine/Features/Collision/Shapes.h
@@ -23,7 +23,7 @@ struct AABB
     Matrix4x4 worldMat;
 
     AABB() = default;
-    AABB(const float* _min, const float* _max) : referencePoint{ 0.0f }, center{ 0.0f }, vertices{ 0.0f }
+    AABB(const float* _min, const float* _max) : referencePoint{ 0.0f }, center{ 0.0f }, vertices{ 0.0f }, worldMat{ Matrix4x4::Identity() }
     {
         localMin = _min;
         localMax = _max;

--- a/Engine/Features/Model/Animation/ModelAnimation.cpp
+++ b/Engine/Features/Model/Animation/ModelAnimation.cpp
@@ -106,7 +106,7 @@ void ModelAnimation::ReadAnimation(const aiAnimation* _animation)
 {
     animation_.duration = static_cast<float> (_animation->mDuration / _animation->mTicksPerSecond);
 
-    for (int32_t channelIndex = 0; channelIndex < _animation->mNumChannels; ++channelIndex)
+    for (uint32_t channelIndex = 0; channelIndex < _animation->mNumChannels; ++channelIndex)
     {
         aiNodeAnim* aiNodeAnimation = _animation->mChannels[channelIndex];
         NodeAnimation& nodeAnimation = animation_.nodeAnimations[aiNodeAnimation->mNodeName.C_Str()];
@@ -116,7 +116,7 @@ void ModelAnimation::ReadAnimation(const aiAnimation* _animation)
 
         nodeAnimation.interpolation = interpolation;
 
-        for (int32_t keyframeIndex = 0; keyframeIndex < aiNodeAnimation->mNumPositionKeys; ++keyframeIndex)
+        for (uint32_t keyframeIndex = 0; keyframeIndex < aiNodeAnimation->mNumPositionKeys; ++keyframeIndex)
         {
             aiVectorKey& aiKeyframe = aiNodeAnimation->mPositionKeys[keyframeIndex];
             KeyframeVector3 keyframe;
@@ -133,7 +133,7 @@ void ModelAnimation::ReadAnimation(const aiAnimation* _animation)
             keyframe.value = Quaternion(aiKeyframe.mValue.x, -aiKeyframe.mValue.y, -aiKeyframe.mValue.z, aiKeyframe.mValue.w).Normalize();
             nodeAnimation.rotation.keyframes.push_back(keyframe);
         }
-        for (int32_t keyframeIndex = 0; keyframeIndex < aiNodeAnimation->mNumScalingKeys; ++keyframeIndex)
+        for (uint32_t keyframeIndex = 0; keyframeIndex < aiNodeAnimation->mNumScalingKeys; ++keyframeIndex)
         {
             aiVectorKey& aiKeyframe = aiNodeAnimation->mScalingKeys[keyframeIndex];
             KeyframeVector3 keyframe;
@@ -209,6 +209,13 @@ void ModelAnimation::ToIdle(float _timeToIdle)
     timeToIdle_ = _timeToIdle;
 }
 
+void ModelAnimation::Reset()
+{
+    animetionTimer_ = 0.0f;
+    isPlaying_ = false;
+    toIdle_ = false;
+    timeToIdle_ = 0.0f;
+}
 
 Vector3 ModelAnimation::CalculateValue_Linear(const AnimationCurve<Vector3>& _curve, float _time)
 {

--- a/Engine/Features/Model/Animation/ModelAnimation.h
+++ b/Engine/Features/Model/Animation/ModelAnimation.h
@@ -28,6 +28,7 @@ public:
     void ReadSampler(const std::string& _filepath);
 
     void ToIdle(float _timeToIdle);
+    void Reset();
 
     void SetLoop(bool _loop) { isLoop_ = _loop; }
 

--- a/Engine/Features/Model/Model.cpp
+++ b/Engine/Features/Model/Model.cpp
@@ -166,6 +166,7 @@ void Model::SetAnimation(const std::string& _name,bool _loop)
     }
     currentAnimation_ = animation_[_name].get();
     currentAnimation_->SetLoop(_loop);
+    currentAnimation_->Reset();
 }
 
 void Model::ToIdle(float _timeToIdle)


### PR DESCRIPTION
`Shapes.h` の `AABB` 構造体のコンストラクタに `worldMat` の初期化が追加されました。

`ModelAnimation.cpp` の `ReadAnimation` 関数内で、ループ変数の型が `int32_t` から `uint32_t` に変更されました。

`ModelAnimation.cpp` に `Reset` 関数が追加されました。この関数は `animetionTimer_`、`isPlaying_`、`toIdle_`、`timeToIdle_` をリセットします。

`ModelAnimation.h` に `Reset` 関数の宣言が追加されました。

`Model.cpp` の `SetAnimation` 関数内で、アニメーションを設定する際に `Reset` 関数が呼び出されるようになりました。