### PR TITLE
シーンマネージャーにトランジション機能を追加

### DIFF
--- a/Engine/Features/Scene/Manager/SceneManager.cpp
+++ b/Engine/Features/Scene/Manager/SceneManager.cpp
@@ -46,11 +46,32 @@ void SceneManager::Update()
     ImGui();
 #endif // _DEBUG
     currentScene_->Update();
+    if (isTransition_)
+    {
+        transition_->Update();
+        if (transition_->IsEnd())
+        {
+            isTransition_ = false;
+        }
+    }
 }
 
 void SceneManager::Draw()
 {
     currentScene_->Draw();
+    if (isTransition_)
+    {
+        transition_->Draw();
+    }
+}
+
+void SceneManager::SetTransition(std::unique_ptr<ISceneTransition> _transition)
+{
+    if (_transition != nullptr)
+    {
+        transition_ = std::move(_transition);
+        transition_->Initialize();
+    }
 }
 
 void SceneManager::ReserveScene(const std::string& _name)
@@ -58,6 +79,12 @@ void SceneManager::ReserveScene(const std::string& _name)
     auto instance = GetInstance();
 
     instance->nextSceneName_ = _name;
+
+    if (instance->transition_ != nullptr)
+    {
+        instance->transition_->Start();
+        instance->isTransition_ = true;
+    }
 }
 
 
@@ -70,6 +97,15 @@ void SceneManager::ChangeScene()
     {
         return;
     }
+
+    if (instance->transition_ != nullptr)
+    {
+        if (!instance->transition_->CanSwitch())
+        {
+            return;
+        }
+    }
+
 
     instance->currentScene_.reset();
 

--- a/Engine/Features/Scene/Manager/SceneManager.h
+++ b/Engine/Features/Scene/Manager/SceneManager.h
@@ -33,6 +33,8 @@ public:
     // 描画
     void Draw();
 
+    void SetTransition(std::unique_ptr<ISceneTransition> _transition);
+
     // シーンの予約
     // _name : 予約するシーンの名前
     static void ReserveScene(const std::string& _name);
@@ -49,6 +51,9 @@ private:
 
     // 現在のシーン
     std::unique_ptr<BaseScene> currentScene_ = nullptr;
+
+    std::unique_ptr<ISceneTransition> transition_ = nullptr;
+    bool isTransition_ = false;
 
     // 現在のシーン名
     std::string currentSceneName_ = {};

--- a/Engine/Features/Sprite/Sprite.cpp
+++ b/Engine/Features/Sprite/Sprite.cpp
@@ -96,6 +96,11 @@ void Sprite::SetSize(const Vector2& _size)
     scale_ = _size / defaultTextureSize_;
 }
 
+void Sprite::SetColor(const Vector4& _color)
+{
+    color_ = _color;
+}
+
 void Sprite::SetUVSize(const Vector2& _size)
 {
     uvScale_ = _size / defaultTextureSize_;

--- a/Engine/Features/Sprite/Sprite.h
+++ b/Engine/Features/Sprite/Sprite.h
@@ -39,6 +39,7 @@ public:
     void SetAnchor(const Vector2& _anchor) { anchor_ = _anchor; CalculateVertex(); }
 
     void SetSize(const Vector2& _size);
+    void SetColor(const Vector4& _color);
 
     void SetUVSize(const Vector2& _size);
     void SetLeftTop(const Vector2& _leftTop);

--- a/Engine/Features/Sprite/SpriteManager.cpp
+++ b/Engine/Features/Sprite/SpriteManager.cpp
@@ -29,6 +29,8 @@ void SpriteManager::PreDraw()
 {
     auto commandList = DXCommon::GetInstance()->GetCommandList();
 
+    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
     commandList->SetGraphicsRootSignature(rootSignature_);
     commandList->SetPipelineState(graphicsPipelineState_);
 }

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -670,5 +670,6 @@
     <ClInclude Include="Utility\ConvertString\ConvertString.h">
       <Filter>Utility\ConvertString</Filter>
     </ClInclude>
+    <ClInclude Include="ISceneTransition.h" />
   </ItemGroup>
 </Project>

--- a/Engine/ISceneTransition.h
+++ b/Engine/ISceneTransition.h
@@ -1,0 +1,19 @@
+#pragma once
+
+class ISceneTransition
+{
+public:
+    virtual ~ISceneTransition() = default;
+
+    virtual void Initialize() = 0;
+
+    virtual void Update() = 0;
+    virtual void Draw() = 0;
+    virtual void Start() = 0;
+    virtual void End() = 0;
+
+    virtual bool IsEnd() = 0;
+    virtual bool CanSwitch() = 0;
+
+
+};


### PR DESCRIPTION
シーンマネージャーにトランジション機能を追加しました。以下の変更が含まれます:
- `SceneManager.cpp` の `Update` メソッドにトランジションの更新処理を追加
- `SceneManager.cpp` の `Draw` メソッドにトランジションの描画処理を追加
- `SceneManager.cpp` に `SetTransition` メソッドを追加
- `SceneManager.cpp` の `ReserveScene` メソッドにトランジションの開始処理を追加
- `SceneManager.cpp` の `ChangeScene` メソッドにトランジションの中断処理を追加
- `SceneManager.h` に `ISceneTransition.h` のインクルードとメソッド宣言、メンバ変数を追加
- `GameEngine.vcxproj` と `GameEngine.vcxproj.filters` に `ISceneTransition.h` のインクルードを追加
- `ISceneTransition.h` を新規追加し、トランジションのインターフェースを定義
- `MyGame.cpp` に `SceneTransition.h` のインクルードを追加
- `Sprite.cpp` と `Sprite.h` に `SetColor` メソッドを追加
- `SpriteManager.cpp` の `PreDraw` メソッドにプリミティブトポロジー設定を追加
- 複数の `.pdb` ファイルにバイナリの変更