### PR TITLE
線分ごとに色を指定できるよう変更

### DIFF
--- a/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
@@ -569,11 +569,18 @@ void PSOManager::CreatePSOForLineDrawer(PSOFlags _flags)
 
 #pragma region InputLayout
     /// InputLayoutの設定を行う
-    D3D12_INPUT_ELEMENT_DESC inputElementDescs[1] = {};
+    D3D12_INPUT_ELEMENT_DESC inputElementDescs[2] = {};
     inputElementDescs[0].SemanticName = "POSITION";
     inputElementDescs[0].SemanticIndex = 0;
     inputElementDescs[0].Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
     inputElementDescs[0].AlignedByteOffset = D3D12_APPEND_ALIGNED_ELEMENT;
+
+    inputElementDescs[1].SemanticName = "COLOR";
+    inputElementDescs[1].SemanticIndex = 0;
+    inputElementDescs[1].Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+    inputElementDescs[1].AlignedByteOffset = D3D12_APPEND_ALIGNED_ELEMENT;
+
+
 
     D3D12_INPUT_LAYOUT_DESC inputLayoutDesc{};
     inputLayoutDesc.pInputElementDescs = inputElementDescs;

--- a/Engine/Features/LineDrawer/LineDrawer.cpp
+++ b/Engine/Features/LineDrawer/LineDrawer.cpp
@@ -46,10 +46,18 @@ void LineDrawer::Initialize()
 
 void LineDrawer::RegisterPoint(const Vector3& _start, const Vector3& _end)
 {
+    RegisterPoint(_start, _end, color_);
+}
+
+void LineDrawer::RegisterPoint(const Vector3& _start, const Vector3& _end, const Vector4& _color)
+{
     assert(index + 2 < kMaxNum && "The line instance is too large");
 
-    vConstMap_[index++].position = { _start, 1.0f };
-    vConstMap_[index++].position = { _end, 1.0f };
+    vConstMap_[index].position = { _start, 1.0f };
+    vConstMap_[index++].color = _color;
+
+    vConstMap_[index].position = { _end, 1.0f };
+    vConstMap_[index++].color = _color;
 }
 
 void LineDrawer::Draw()
@@ -73,20 +81,27 @@ void LineDrawer::Draw()
 
 void LineDrawer::DrawOBB(const Matrix4x4& _affineMat)
 {
+    DrawOBB(_affineMat, color_);
+}
+
+void LineDrawer::DrawOBB(const Matrix4x4& _affineMat, const Vector4& _color)
+{
     for (uint32_t index = 1; index < obbIndices_.size(); index += 2)
     {
         uint32_t sIndex = obbIndices_[index - 1];
         uint32_t eIndex = obbIndices_[index];
-
         Vector3 spos = Transform(obbVertices_[sIndex], _affineMat);
         Vector3 epos = Transform(obbVertices_[eIndex], _affineMat);
-
-        RegisterPoint(spos, epos);
+        RegisterPoint(spos, epos, _color);
     }
-
 }
 
 void LineDrawer::DrawOBB(const std::array<Vector3, 8>& _vertices)
+{
+    DrawOBB(_vertices, color_);
+}
+
+void LineDrawer::DrawOBB(const std::array<Vector3, 8>& _vertices, const Vector4& _color)
 {
     for (uint32_t index = 1; index < obbIndices_.size(); index += 2)
     {
@@ -96,11 +111,16 @@ void LineDrawer::DrawOBB(const std::array<Vector3, 8>& _vertices)
         Vector3 spos = _vertices[sIndex];
         Vector3 epos = _vertices[eIndex];
 
-        RegisterPoint(spos, epos);
+        RegisterPoint(spos, epos, _color);
     }
 }
 
 void LineDrawer::DrawSphere(const Matrix4x4& _affineMat)
+{
+    DrawSphere(_affineMat, color_);
+}
+
+void LineDrawer::DrawSphere(const Matrix4x4& _affineMat, const Vector4& _color)
 {
     for (uint32_t index = 1; index < sphereIndices_.size(); index += 2)
     {
@@ -110,11 +130,16 @@ void LineDrawer::DrawSphere(const Matrix4x4& _affineMat)
         Vector3 spos = Transform(sphereVertices_[sIndex], _affineMat);
         Vector3 epos = Transform(sphereVertices_[eIndex], _affineMat);
 
-        RegisterPoint(spos, epos);
+        RegisterPoint(spos, epos, _color);
     }
 }
 
 void LineDrawer::DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal)
+{
+    DrawCircle(_center, _radius, _segmentCount, _normal, color_);
+}
+
+void LineDrawer::DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal, const Vector4& _color)
 {
     // 法線を正規化
     Vector3 normal = _normal.Normalize();
@@ -162,7 +187,6 @@ void LineDrawer::DrawCircle(const Vector3& _center, float _radius, const float _
 
 void LineDrawer::TransferData()
 {
-    constMap_->color = color_;
     constMap_->vp = cameraptr_->GetViewProjection();
 }
 

--- a/Engine/Features/LineDrawer/LineDrawer.h
+++ b/Engine/Features/LineDrawer/LineDrawer.h
@@ -21,12 +21,18 @@ public:
     void SetCameraPtr(const Camera* _cameraPtr) { cameraptr_ = _cameraPtr; }
     void SetColor(const Vector4& _color) { color_ = _color; }
     void RegisterPoint(const Vector3& _start, const Vector3& _end);
+    void RegisterPoint(const Vector3& _start, const Vector3& _end,const Vector4& _color);
     void Draw();
 
     void DrawOBB(const Matrix4x4& _affineMat);
+    void DrawOBB(const Matrix4x4& _affineMat, const Vector4& _color);
     void DrawOBB(const std::array <Vector3, 8>& _vertices);
+    void DrawOBB(const std::array <Vector3, 8>& _vertices, const Vector4& _color);
+
     void DrawSphere(const Matrix4x4& _affineMat);
+    void DrawSphere(const Matrix4x4& _affineMat, const Vector4& _color);
     void DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal);
+    void DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal, const Vector4& _color);
 
 private:
     void TransferData();
@@ -43,7 +49,6 @@ private:
     struct ConstantBufferData
     {
         Matrix4x4 vp;
-        Vector4 color;
     };
     Microsoft::WRL::ComPtr <ID3D12Resource> resources_ = nullptr;
     ConstantBufferData* constMap_;
@@ -51,6 +56,7 @@ private:
     struct PointData
     {
         Vector4 position;
+        Vector4 color;
     };
 
     PointData* vConstMap_ = nullptr;

--- a/Sample/Resources/Shader/LineDrawer.VS.hlsl
+++ b/Sample/Resources/Shader/LineDrawer.VS.hlsl
@@ -4,12 +4,13 @@
 struct VSInput
 {
 	float4 position : POSITION0;
+    float4 color : COLOR0;
 };
 
 VertexShaderOutput main(VSInput _input)
 {
 	VertexShaderOutput output;
 	output.position = mul(_input.position, vp);
-	output.color = color;
+    output.color = _input.color;
 	return output;
 }

--- a/Sample/Resources/Shader/LineDrawer.hlsli
+++ b/Sample/Resources/Shader/LineDrawer.hlsli
@@ -7,5 +7,4 @@ struct VertexShaderOutput
 cbuffer constBuf0 : register(b0)
 {
     float4x4 vp;
-	float4 color;
 }


### PR DESCRIPTION
PSOManager.cppで入力レイアウトに"COLOR"セマンティクスを追加し、`inputElementDescs`のサイズを変更しました。 LineDrawer.cppでは、`RegisterPoint`メソッドをオーバーロードし、色を引数として受け取るようにしました。 `DrawOBB`、`DrawSphere`、`DrawCircle`メソッドも同様に更新され、描画時に指定した色を使用するようになりました。 LineDrawer.hでは、関連するメソッドの宣言を更新し、`ConstantBufferData`から`color`メンバーを削除し、`PointData`に追加しました。 LineDrawer.VS.hlslでは、頂点シェーダーの入力構造体に`color`フィールドを追加し、シェーダー内で色を正しく処理できるようにしました。