### PR TITLE
JSONバインダーの初期化とレイヤー管理の改善

### DIFF
--- a/Engine/Features/Collision/CollisionLayer/CollisionLayerManager.cpp
+++ b/Engine/Features/Collision/CollisionLayer/CollisionLayerManager.cpp
@@ -1,5 +1,7 @@
 #include "CollisionLayerManager.h"
 
+#include <Features/Json/JsonBinder.h>
+
 CollisionLayerManager* CollisionLayerManager::GetInstance()
 {
     static CollisionLayerManager instance;
@@ -17,11 +19,27 @@ uint32_t CollisionLayerManager::GetLayer(const std::string& _layer)
     // 登録されていない場合新たに登録する
     layerMap_[_layer] = static_cast <uint32_t>(1 << layerMap_.size());
 
+    layerNames_.push_back(_layer);
+
     // 登録したLayerを返す
     uint32_t result = layerMap_[_layer];
     return result;
 }
 
+void CollisionLayerManager::InitJsonBinder()
+{
+    jsonBinder_ = std::make_unique<JsonBinder>("CollisionLayer", "Resources/Data/CollisionLayer/");
+    jsonBinder_->RegisterVariable("layerNames", &layerNames_);
+}
+
 CollisionLayerManager::CollisionLayerManager()
 {
+    InitJsonBinder();
+}
+
+CollisionLayerManager::~CollisionLayerManager()
+{
+    jsonBinder_->Save();
+
+    jsonBinder_.reset();
 }

--- a/Engine/Features/Collision/CollisionLayer/CollisionLayerManager.h
+++ b/Engine/Features/Collision/CollisionLayer/CollisionLayerManager.h
@@ -3,7 +3,10 @@
 #include <string>
 #include <unordered_map>
 #include <cstdint>
+#include <vector>
+#include <memory>
 
+class JsonBinder;
 class CollisionLayerManager
 {
 public:
@@ -12,14 +15,20 @@ public:
     // Layerを取得する
     uint32_t GetLayer(const std::string& _layer);
 
+    void InitJsonBinder();
+
 private:
 
     // Layerのマップ
     std::unordered_map<std::string, uint32_t> layerMap_;
+    std::vector<std::string> layerNames_;
+
+    std::unique_ptr<JsonBinder> jsonBinder_;
+
 
 private:
     CollisionLayerManager();
-    ~CollisionLayerManager() = default;
+    ~CollisionLayerManager();
     CollisionLayerManager(const CollisionLayerManager&) = delete;
     CollisionLayerManager& operator=(const CollisionLayerManager&) = delete;
 


### PR DESCRIPTION
`CollisionLayerManager`に`JsonBinder`を追加し、JSONデータの初期化と保存を行うメソッド`InitJsonBinder`を実装しました。レイヤー名を格納する`layerNames_`ベクターを追加し、レイヤー取得時にこのベクターにレイヤー名を追加する処理を追加しました。ヘッダーファイルでは、これらのメンバー変数とメソッドの宣言を行い、デストラクタをカスタムに変更しました。