### PR TITLE
デバッグウィンドウと描画制御の改善

### DIFF
--- a/Engine/Debug/ImGuiDebugManager.cpp
+++ b/Engine/Debug/ImGuiDebugManager.cpp
@@ -94,6 +94,7 @@ void ImGuiDebugManager::ShowDebugWindow()
         i = 0;
         for (auto& [name, func] : colliderDebugWindows_)
         {
+            if (name == "CollisionManager") continue;
             bool flag = colliderIsSelect_[i];
             if (ImGui::Selectable(name.c_str(), &flag))
                 colliderIsSelect_[i] = flag;
@@ -125,11 +126,16 @@ void ImGuiDebugManager::ShowDebugWindow()
         }
         ImGui::EndTabBar();
 
+        ImGui::SeparatorText("Colliders");
+        colliderDebugWindows_["CollisionManager"]();
         ImGui::BeginTabBar("ColliderDebugWindow", tabBarFlags_);
         {
+
             size_t i = 0;
             for (auto& [name, func] : colliderDebugWindows_)
             {
+                if (name == "CollisionManager") continue;
+
                 if (colliderIsSelect_[i])
                 {
                     bool flag = colliderIsSelect_[i];

--- a/Engine/Features/Collision/Collider/Collider.cpp
+++ b/Engine/Features/Collision/Collider/Collider.cpp
@@ -116,6 +116,7 @@ void Collider::ImGui()
     ImGui::Text("Layer      : %x", collisionLayer_.GetLayer());
     ImGui::Text("LayerMask  : %x", collisionLayer_.GetLayerMask());
     ImGui::Text("BoundingBox: %s", ToString(boundingBox_).c_str());
+    ImGui::Checkbox("Draw", &isDraw_);
 
 #endif // _DEBUG
 
@@ -182,6 +183,9 @@ SphereCollider::SphereCollider(const std::string& _name) : Collider()
 
 void SphereCollider::Draw()
 {
+    if (!isDraw_)
+        return;
+
     // 球を描画
     // 球の中心をワールド空間に変換
     Vector3 center = GetWorldTransform()->transform_;
@@ -238,6 +242,9 @@ AABBCollider::AABBCollider(const std::string& _name) : Collider()
 
 void AABBCollider::Draw()
 {
+    if (!isDraw_)
+        return;
+
     // AABBを描画するために8つの頂点を計算
     std::array<Vector3, 8> vertices;
 
@@ -337,6 +344,9 @@ OBBCollider::OBBCollider(const std::string& _name) : Collider()
 
 void OBBCollider::Draw()
 {
+    if (!isDraw_)
+        return;
+
     std::vector<Vector3> corners = GetVertices();
 
     std::array<Vector3, 8> c;
@@ -467,6 +477,9 @@ CapsuleCollider::CapsuleCollider(const std::string& _name) : Collider()
 
 void CapsuleCollider::Draw()
 {
+    if (!isDraw_)
+        return;
+
     // カプセルの中心線の両端を取得
     Vector3 start, end;
     GetCapsuleSegment(start, end);

--- a/Engine/Features/Collision/Collider/Collider.h
+++ b/Engine/Features/Collision/Collider/Collider.h
@@ -148,6 +148,8 @@ protected:
     JsonBinder* jsonBinder_ = nullptr;
 
     std::string name_;
+
+    bool isDraw_ = true;
 private:
     // 衝突状態の管理
     struct CollisionData

--- a/Engine/Features/Collision/Manager/CollisionManager.cpp
+++ b/Engine/Features/Collision/Manager/CollisionManager.cpp
@@ -1,5 +1,6 @@
 #include "CollisionManager.h"
 #include <Features/LineDrawer/LineDrawer.h>
+#include <Debug/ImGuiDebugManager.h>
 #include <algorithm>
 
 CollisionManager* CollisionManager::GetInstance()
@@ -174,6 +175,15 @@ void CollisionManager::DrawColliders()
     }
 }
 
+void CollisionManager::ImGui()
+{
+    ImGui::PushID(this);
+    // デバッグ描画の有効/無効を設定
+    ImGui::Checkbox("Draw Colliders", &isDrawEnabled_);
+
+    ImGui::PopID();
+}
+
 void CollisionManager::ResolveCollision(const CollisionPair& _pair)
 {
     // 両方のコライダーに衝突通知を送る
@@ -194,4 +204,9 @@ void CollisionManager::UpdateBroadPhase()
 {
     // 空間分割などの最適化を行う場合はここに実装
     // 現在は単純な総当たりで実装
+}
+
+CollisionManager::CollisionManager()
+{
+    ImGuiDebugManager::GetInstance()->AddColliderDebugWindow("CollisionManager", [&]() {ImGui(); });
 }

--- a/Engine/Features/Collision/Manager/CollisionManager.h
+++ b/Engine/Features/Collision/Manager/CollisionManager.h
@@ -43,6 +43,8 @@ public:
     // デバッグ描画の有効/無効を取得
     bool IsDrawEnabled() const { return isDrawEnabled_; }
 
+    void ImGui();
+
 private:
     // 衝突応答を実行する
     void ResolveCollision(const CollisionPair& _pair);
@@ -65,7 +67,7 @@ private:
 
 private:
     // コンストラクタ
-    CollisionManager() = default;
+    CollisionManager();
 
     // デストラクタ
     ~CollisionManager() = default;


### PR DESCRIPTION
`ImGuiDebugManager::ShowDebugWindow` において、"CollisionManager" コライダーをスキップする条件を追加し、コライダーのデバッグウィンドウ表示処理を強化しました。

`Collider` クラスの `ImGui` メソッドに描画制御用のチェックボックスを追加し、各コライダーの `Draw` メソッドに描画フラグのチェックを実装しました。

`CollisionManager` クラスに `ImGui` メソッドを追加し、デバッグ描画の有効/無効を設定できるようにしました。また、コンストラクタを明示的に変更し、デバッグウィンドウ追加処理を組み込みました。