### PR TITLE
デバッグウィンドウの管理と新メソッドの追加

### DIFF
--- a/Engine/Features/Collision/Collider/Collider.cpp
+++ b/Engine/Features/Collision/Collider/Collider.cpp
@@ -19,7 +19,10 @@ void Collider::Initialize()
 
 Collider::~Collider()
 {
+#ifdef _DEBUG
     ImGuiDebugManager::GetInstance()->RemoveDebugWindow(name_);
+#endif // _DEBUG
+
 }
 
 void Collider::OnCollision(Collider* _other, const ColliderInfo& _info)
@@ -186,9 +189,12 @@ void Collider::UpdateCollisionState()
 SphereCollider::SphereCollider(const std::string& _name) : Collider()
 {
     SetBoundingBox(BoundingBox::Sphere_3D);
+#ifdef _DEBUG
 
     name_ = ImGuiDebugManager::GetInstance()->AddColliderDebugWindow(_name, [&]() {ImGui(); });
+#endif // _DEBUG
 }
+
 
 
 void SphereCollider::Draw()
@@ -246,8 +252,10 @@ void SphereCollider::ImGui()
 AABBCollider::AABBCollider(const std::string& _name) : Collider()
 {
     SetBoundingBox(BoundingBox::AABB_3D);
-
+#ifdef _DEBUG
     name_ = ImGuiDebugManager::GetInstance()->AddColliderDebugWindow(_name, [&]() {ImGui(); });
+#endif // _DEBUG
+
 }
 
 void AABBCollider::Draw()
@@ -348,8 +356,11 @@ void AABBCollider::ImGui()
 OBBCollider::OBBCollider(const std::string& _name) : Collider()
 {
     SetBoundingBox(BoundingBox::OBB_3D);
+#ifdef _DEBUG
+
 
     name_ = ImGuiDebugManager::GetInstance()->AddColliderDebugWindow(_name, [&]() {ImGui(); });
+#endif // _DEBUG
 }
 
 void OBBCollider::Draw()
@@ -483,8 +494,11 @@ void OBBCollider::ImGui()
 CapsuleCollider::CapsuleCollider(const std::string& _name) : Collider()
 {
     SetBoundingBox(BoundingBox::Capsule_3D);
-
+#ifdef _DEBUG
     name_ = ImGuiDebugManager::GetInstance()->AddColliderDebugWindow(_name, [&]() {ImGui(); });
+
+#endif // _DEBUG
+
 }
 
 void CapsuleCollider::Draw()

--- a/Engine/Features/Light/Point/PointLight.cpp
+++ b/Engine/Features/Light/Point/PointLight.cpp
@@ -38,7 +38,7 @@ void PointLightComponent::CreateShadowMaps(uint32_t shadowMapSize)
     // 6面分のシャドウマップを作成
     std::string mapName = name_ + "_ShadowMap";
 
-    uint32_t handle = 0
+    uint32_t handle = 0;
         /*RTVManager::GetInstance()->CreateCubemapRenderTarget(
         mapName,
         shadowMapSize,


### PR DESCRIPTION
Colliderクラスおよびその派生クラスにおいて、デバッグビルド時の`ImGuiDebugManager`を使用したデバッグウィンドウの追加・削除が行われました。特に、SphereCollider、AABBCollider、OBBCollider、CapsuleColliderに`Draw`メソッドが新たに追加されました。また、PointLightComponentの`CreateShadowMaps`メソッドでシャドウマップのハンドル初期化が修正されました。