### PR TITLE
レンダリングターゲットのクリア処理と改善

### DIFF
--- a/Sample/Resources/Data/CollisionLayer/CollisionLayer.json
+++ b/Sample/Resources/Data/CollisionLayer/CollisionLayer.json
@@ -1,0 +1,12 @@
+{
+    "CollisionLayer": {
+        "layerNames": [
+            "cube",
+            "cube2",
+            "cube",
+            "cube2",
+            "cube",
+            "cube2"
+        ]
+    }
+}

--- a/Sample/Resources/Shader/PointLightShadowMap.hlsl
+++ b/Sample/Resources/Shader/PointLightShadowMap.hlsl
@@ -1,0 +1,103 @@
+struct VSInput
+{
+    float4 position : POSITION0;
+    float2 texcoord : TEXCOORD0;
+    float3 normal : NORMAL0;
+};
+
+struct VSOutput
+{
+    float4 position : SV_Position;
+};
+
+struct GSOutput
+{
+    float4 Position : SV_POSITION; // クリップ空間の座標
+    float4 WorldPos : TEXCOORD0; // ワールド座標（距離計算用）
+    uint RTIndex : SV_RenderTargetArrayIndex; // レンダーターゲット配列インデックス
+};
+
+struct PSOutput
+{
+    float4 data : SV_TARGET0;
+};
+
+cbuffer TransformationMatrix : register(b0)
+{
+    float4x4 World;
+    float4x4 worldInverseTranspose;
+};
+
+
+struct PointLight
+{
+    float4 color;
+    float3 position;
+    float intensity;
+    float radius;
+    float decay;
+    int isHalf;
+
+    float4x4 lightVP[6];
+};
+
+cbuffer gLightGroup : register(b1)
+{
+    PointLight PL;
+};
+
+cbuffer id : register(b2)
+{
+    uint id;
+}
+
+VSOutput VSmain(VSInput _input)
+{
+    VSOutput output;
+
+    output.position = mul(_input.position, World);
+
+    return output;
+}
+
+[maxvertexcount(18)] // 三角形 × 6面 = 最大18頂点
+void GSmain(triangle VSOutput input[3], inout TriangleStream<GSOutput> TriStream)
+{
+    // 6つの面（キューブマップの各方向）に対して処理
+    for (uint face = 0; face < 6; face++)
+    {
+        // 三角形の3頂点を処理
+        for (uint v = 0; v < 3; v++)
+        {
+            GSOutput output;
+
+            // ワールド座標を保存（距離計算用）
+            output.WorldPos = input[v].position; // 既にワールド座標
+
+            // ライトの視点でのクリップ空間座標に変換
+            output.Position = mul(input[v].position, PL.lightVP[face]);
+
+            // どのキューブマップの面にレンダリングするかを指定
+            output.RTIndex = face;
+
+            TriStream.Append(output);
+        }
+
+        // 三角形ストリップの終了
+        TriStream.RestartStrip();
+    }
+}
+
+PSOutput PSmain(GSOutput input)
+{
+    PSOutput output;
+
+    float r = (id & 0xFF) / 255.0; // 下位8bit
+    float g = ((id >> 8) & 0xFF) / 255.0; // 中位8bit
+    float b = ((id >> 16) & 0xFF) / 255.0; // 上位8bit
+
+    float a = 1.0f;
+    output.data = float4(r, g, b, a);
+
+    return output;
+}

--- a/Sample/SampleFramework.cpp
+++ b/Sample/SampleFramework.cpp
@@ -24,6 +24,8 @@ void SampleFramework::Update()
 {
     Framework::Update();
 
+    rtvManager_->ClearAllRenderTarget();
+
 
     //========== 更新処理 =========
 

--- a/Sample/SampleScene.cpp
+++ b/Sample/SampleScene.cpp
@@ -49,7 +49,7 @@ void SampleScene::Initialize()
     uint32_t textureHandle = TextureManager::GetInstance()->Load("uvChecker.png");
     sprite_ = Sprite::Create("uvChecker", textureHandle);
 
-    lights_ = std::make_unique<LightGroup>();
+    lights_ = std::make_shared<LightGroup>();
     lights_->Initialize();
 
     colors.push_back({ 0.0f,Vector4(1,0,0,1) });
@@ -110,7 +110,7 @@ void SampleScene::Update()
     ImGuiTool::TimeLine("TimeLine", sequence_.get());
     ImGuiTool::GradientEditor("GradientEditor", colors);
 
-    lights_->DrawDebugWindow();
+    lights_->ImGui();
 
     static bool play = false;
     if (ImGui::Button("Play"))
@@ -129,7 +129,7 @@ void SampleScene::Update()
         cubeCollider2_->Save("cube2");
     }
 #endif // _DEBUG
-    LightingSystem::GetInstance()->SetLightGroup(lights_.get());
+    LightingSystem::GetInstance()->SetActiveGroup(lights_);
 
 
     oModel_->Update();
@@ -187,8 +187,6 @@ void SampleScene::Draw()
 
 void SampleScene::DrawShadow()
 {
-    PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type_ShadowMap);
-    PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type_ShadowMap);
 
     oModel_->DrawShadow(&SceneCamera_, 0);
     oModel2_->DrawShadow(&SceneCamera_, 1);

--- a/Sample/SampleScene.h
+++ b/Sample/SampleScene.h
@@ -52,7 +52,7 @@ private:
 
     std::unique_ptr <Sprite> sprite_ = nullptr;
 
-    std::unique_ptr<LightGroup> lights_;
+    std::shared_ptr<LightGroup> lights_;
     std::list<std::pair<float, Vector4>> colors;
 
     std::unique_ptr<AnimationSequence> sequence_ = nullptr;

--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -172,6 +172,11 @@ Pos=261,223
 Size=134,126
 Collapsed=0
 
+[Window][Light Settings]
+Pos=60,60
+Size=207,192
+Collapsed=0
+
 [Table][0xC9935533,3]
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000


### PR DESCRIPTION
`SampleFramework::Initialize`にレンダリングターゲットのクリア処理を追加しました。 `SampleScene`関連のメモリ管理を`std::shared_ptr`に変更し、デバッグウィンドウの描画方法を更新しました。 シャドウマップのパイプライン設定を削除し、描画処理を簡素化しました。
新しいウィンドウ設定と衝突レイヤーの定義を追加し、ポイントライトの影描画用シェーダーを実装しました。