### PR TITLE
particleにtexturehandleを適用されるよう修正

### DIFF
--- a/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
@@ -1,6 +1,7 @@
 #include "ParticleEmitter.h"
 #include <Features/Effect/Manager/ParticleManager.h>
 #include <Features/Model/Manager/ModelManager.h>
+#include <Core/DXCommon/TextureManager/TextureManager.h>
 #include <Debug/ImguITools.h>
 
 void ParticleEmitter::Initialize(const std::string& _name)
@@ -157,6 +158,20 @@ void ParticleEmitter::ShowDebugWindow()
                             useModelName_ = modelName_;
                             strcpy_s(modelPath_, 256, "");
                         }
+                    }
+                    ImGui::TreePop();
+                }
+
+                if (ImGui::TreeNode("Use Texture"))
+                {
+                    ImGui::Text("TextureRoot");
+                    ImGui::InputText("##TextureRoot", textureRoot_, 256);
+
+                    ImGui::Text("TexturePath");
+                    ImGui::InputText("##TexturePath", texturePath_, 256);
+                    if (ImGui::Button("Apply##TexturePath"))
+                    {
+                        initParams_.textureHandle = TextureManager::GetInstance()->Load(texturePath_, textureRoot_);
                     }
                     ImGui::TreePop();
                 }
@@ -335,7 +350,8 @@ void ParticleEmitter::GenerateParticles()
     if (useModelName_ == "")
         useModelName_ = "plane/plane.gltf";
 
-    ParticleManager::GetInstance()->AddParticles(useModelName_, particles, settings);
+
+    ParticleManager::GetInstance()->AddParticles(useModelName_, particles, settings,initParams_.textureHandle);
 }
 
 void ParticleEmitter::InitJsonBinder()

--- a/Engine/Features/Effect/Emitter/ParticleEmitter.h
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.h
@@ -4,7 +4,12 @@
 #include <Core/BlendMode.h>
 #include <Features/Model/Transform/WorldTransform.h>
 #include <Features/Json/JsonBinder.h>
+
 #include <string>
+#include <array>
+#include <memory>
+#include <cstdint>
+
 
 template<typename T>
 struct Range {
@@ -86,6 +91,8 @@ struct ParticleInitParamsForGenerator
 
     std::array<bool, 3> billboard = { false, false, false }; // ビルボードのタイプ
 
+    uint32_t textureHandle = 0; // テクスチャのハンドル
+
 };
 
 class ParticleEmitter
@@ -132,6 +139,8 @@ private:
     char modelPath_[256];
     char modelName_[256];
     char nameBuf_[256];
+    char texturePath_[256];
+    char textureRoot_[256] = "Resources/images/"; // テクスチャのルートパス
 
     bool isOpenTimeline = false;
 

--- a/Engine/Features/Effect/Manager/ParticleManager.cpp
+++ b/Engine/Features/Effect/Manager/ParticleManager.cpp
@@ -186,6 +186,7 @@ void ParticleManager::AddParticles(const std::string& _useModelName, std::vector
     else
     {
         it->second.particles.insert(it->second.particles.end(), _particles.begin(), _particles.end());
+        particles_[key].textureHandle = _textureHandle;
     }
 }
 


### PR DESCRIPTION
テクスチャ管理機能の追加とUIの改善

`ParticleEmitter`にテクスチャ関連のUI要素を追加し、テクスチャパスとルートパスの入力が可能になりました。`GenerateParticles`メソッドでテクスチャハンドルを使用するように変更し、`ParticleInitParamsForGenerator`にテクスチャハンドルを追加しました。さらに、`ParticleManager`の`AddParticles`メソッドでテクスチャハンドルが保存されるようになりました。