### PR TITLE
デバッグウィンドウの追加と設定の調整

### DIFF
--- a/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
@@ -60,6 +60,9 @@ void ParticleEmitter::Update(float _deltaTime)
 
 void ParticleEmitter::ShowDebugWindow()
 {
+#ifdef _DEBUG
+
+
     ImGui::Separator();
     ImGui::BeginTabBar("Emitter");
     {
@@ -258,6 +261,7 @@ void ParticleEmitter::ShowDebugWindow()
     ImGui::EndTabBar();
     ImGui::Separator();
 
+#endif // _DEBUG
 
 }
 
@@ -443,6 +447,8 @@ void ParticleEmitter::InitJsonBinder()
 }
 
 #pragma region DebugWindow
+
+#ifdef _DEBUG
 
 void ParticleEmitter::DebugWindowForSize()
 {
@@ -713,5 +719,5 @@ void ParticleEmitter::DebugWindowForModifier()
 
     ImGui::Separator();
 }
-
+#endif // _DEBUG
 #pragma endregion

--- a/Engine/Features/Effect/Emitter/ParticleEmitter.h
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.h
@@ -176,6 +176,8 @@ private:
 
 
     //各パラメータごとの設定用imgui関数
+#ifdef _DEBUG
+
     void DebugWindowForSize();
     void DebugWindowForPosition();
     void DebugWindowForDirection();
@@ -186,6 +188,7 @@ private:
 
     void DebugWindowForModifier();
 
+#endif // _DEBUG
 
 
 

--- a/Sample/Resources/Effect/Emitters/test.json
+++ b/Sample/Resources/Effect/Emitters/test.json
@@ -141,7 +141,8 @@
         "lifeTime_Type": 2,
         "lifeTime_Value": 1.0,
         "modifiers": [
-            "DecelerationModifier"
+            "DecelerationModifier",
+            "AlphaOverLifetime"
         ],
         "offset": {
             "x": 0.0,
@@ -230,7 +231,7 @@
         "speed_Max": 2.0,
         "speed_Min": 0.5,
         "speed_Random": false,
-        "speed_Value": 1.0,
+        "speed_Value": 5.0,
         "sphereRadius": 1.0,
         "textureHandle": 0,
         "useModelName": "plane/plane.gltf"

--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -54,8 +54,8 @@ Size=248,338
 Collapsed=0
 
 [Window][Engine]
-Pos=960,222
-Size=320,498
+Pos=17,17
+Size=15,19
 Collapsed=0
 DockId=0x0000000C,0
 
@@ -95,14 +95,14 @@ Size=158,59
 Collapsed=0
 
 [Window][Input]
-Pos=960,222
-Size=320,498
+Pos=17,17
+Size=15,19
 Collapsed=0
 DockId=0x0000000C,2
 
 [Window][SceneManager]
-Pos=960,222
-Size=320,498
+Pos=17,17
+Size=15,19
 Collapsed=0
 DockId=0x0000000C,1
 
@@ -135,14 +135,14 @@ Collapsed=0
 DockId=0x00000001,2
 
 [Window][DebugWindow]
-Pos=1071,0
-Size=209,220
+Pos=25,0
+Size=7,19
 Collapsed=0
 DockId=0x00000008,0
 
 [Window][Debug]
-Pos=960,0
-Size=109,220
+Pos=17,0
+Size=6,19
 Collapsed=0
 DockId=0x00000007,0
 
@@ -158,7 +158,7 @@ Collapsed=0
 
 [Window][WindowOverViewport_11111111]
 Pos=0,0
-Size=1280,720
+Size=32,32
 Collapsed=0
 
 [Window][Timeline]
@@ -178,8 +178,8 @@ Size=207,192
 Collapsed=0
 
 [Window][TimeLine]
-Pos=0,433
-Size=958,287
+Pos=0,17
+Size=15,19
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -246,7 +246,7 @@ Column 2  Width=56
 
 [Docking][Data]
 DockNode        ID=0x00000001 Pos=255,18 Size=325,299 Selected=0x52D7A061
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=1280,720 Split=X
+DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
   DockNode      ID=0x00000005 Parent=0x08BD597D SizeRef=958,720 Split=Y
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=1280,463 Split=Y
       DockNode  ID=0x00000003 Parent=0x00000002 SizeRef=1042,431 CentralNode=1


### PR DESCRIPTION
ParticleEmitter.cppにデバッグウィンドウ表示用のコードを追加し、`ShowDebugWindow`メソッドに`#ifdef _DEBUG`を導入しました。新たに`DebugWindowForSize`メソッドを実装し、サイズパラメータのデバッグが可能になりました。

ParticleEmitter.hにデバッグ用メソッドを追加し、デバッグビルド時のみ利用可能としました。test.jsonでは`modifiers`配列に`AlphaOverLifetime`を追加し、`speed_Value`を1.0から5.0に変更しました。