### PR TITLE
グレースケールの実装

### DIFF
--- a/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
@@ -204,8 +204,8 @@ Microsoft::WRL::ComPtr<IDxcBlob> PSOManager::ComplieShader(
 
 void PSOManager::CreatePSOForPostEffect(const std::string& _name,
     const std::wstring& _psFileName,
-    const std::wstring& _entryFuncName = L"main",
-    const std::wstring& _dirPath = L"Resources/Shader/")
+    const std::wstring& _entryFuncName,
+    const std::wstring& _dirPath)
 {
     HRESULT hr = S_FALSE;
 

--- a/Engine/Core/DXCommon/PSOManager/PSOManager.h
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.h
@@ -159,7 +159,7 @@ private:
 
 	std::unordered_map<size_t, Microsoft::WRL::ComPtr<ID3D12PipelineState>> graphicsPipelineStates_;
 	std::unordered_map<size_t, Microsoft::WRL::ComPtr<ID3D12RootSignature>> rootSignatures_;
-    std::unordered_map<const std::string&, Microsoft::WRL::ComPtr<ID3D12PipelineState>> postEffectPipelineStates_;
+    std::unordered_map<std::string, Microsoft::WRL::ComPtr<ID3D12PipelineState>> postEffectPipelineStates_;
 
 
     Microsoft::WRL::ComPtr<IDxcUtils> dxcUtils_;

--- a/Engine/Core/DXCommon/RTV/RTVManager.cpp
+++ b/Engine/Core/DXCommon/RTV/RTVManager.cpp
@@ -61,16 +61,9 @@ void RTVManager::Initialize(size_t _backBufferCount, uint32_t _winWidth, uint32_
 
 void RTVManager::DrawRenderTexture(uint32_t _index)
 {
-
     auto it = renderTargets_.find(_index);
     if (it == renderTargets_.end())
         assert(false && "not found RenderTarget");
-
-    auto psoManager = PSOManager::GetInstance();
-
-    psoManager->SetPipeLineStateObject(PSOFlags::Type_OffScreen);
-    psoManager->SetRootSignature(PSOFlags::Type_OffScreen);
-
 
     it->second->Draw();
 

--- a/Engine/GameEngine.vcxproj
+++ b/Engine/GameEngine.vcxproj
@@ -364,6 +364,10 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </FxCompile>
+    <FxCompile Include="..\Sample\Resources\Shader\GrayScale.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
     <FxCompile Include="..\Sample\Resources\Shader\LineDrawer.PS.hlsl">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -518,7 +518,12 @@
     <FxCompile Include="..\Sample\Resources\Shader\Skinning.CS.hlsl">
       <Filter>HLSL</Filter>
     </FxCompile>
-    <FxCompile Include="PointLightShadowMap.hlsl" />
+    <FxCompile Include="PointLightShadowMap.hlsl">
+      <Filter>HLSL</Filter>
+    </FxCompile>
+    <FxCompile Include="..\Sample\Resources\Shader\GrayScale.hlsl">
+      <Filter>HLSL</Filter>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />

--- a/Sample/Resources/Shader/GrayScale.hlsl
+++ b/Sample/Resources/Shader/GrayScale.hlsl
@@ -1,0 +1,21 @@
+#include  "Resources/Shader/FullScreen.hlsli"
+//#include "FullScreen.hlsli"
+
+Texture2D<float4> gTexture : register(t0);
+SamplerState gSampler : register(s0);
+
+struct PixelShaderOutput
+{
+    float4 color : SV_Target0;
+};
+
+PixelShaderOutput main(VertexOutput _input)
+{
+    PixelShaderOutput output;
+    output.color = gTexture.Sample(gSampler, _input.uv);
+    float value = dot(output.color.rgb, float3(0.2125f, 0.7154f, 0.0721f));
+    output.color.rgb = float3(value, value, value);
+    output.color.a = 1.0f;
+    return output;
+}
+

--- a/Sample/SampleFramework.cpp
+++ b/Sample/SampleFramework.cpp
@@ -15,6 +15,9 @@ void SampleFramework::Initialize()
     rtvManager_->CreateRenderTarget("default", WinApp::kWindowWidth_, WinApp::kWindowHeight_, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Vector4(0.4625f, 0.925f, 0.4625f, 1.0f), false);
     rtvManager_->CreateRenderTarget("ShadowMap", 4096, 4096, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,  Vector4(1.0f, 1.0f, 1.0f, 1.0f),true);
 
+    PSOManager::GetInstance()->CreatePSOForPostEffect("GrayScale", L"GrayScale.hlsl");
+
+
     sceneManager_->SetSceneFactory(new SceneFactory());
     particleManager_->SetModifierFactory(new ParticleModifierFactory());
 
@@ -53,10 +56,17 @@ void SampleFramework::Draw()
     lineDrawer_->Draw();
     //=============================
 
+    PSOManager::GetInstance()->SetPSOForPostEffect("GrayScale");
+    rtvManager_->DrawRenderTexture("default");
+
 
     dxCommon_->PreDraw();
     // スワップチェインに戻す
     rtvManager_->SetSwapChainRenderTexture(dxCommon_->GetSwapChain());
+
+    PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type_OffScreen);
+    PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type_OffScreen);
+
     // レンダーテクスチャを描画
     rtvManager_->DrawRenderTexture("default");
 


### PR DESCRIPTION
PSOManagerの軽微な修正
RenderTargetのDraw関数内でrootsignatureとpsoを積むのを外に追い出した。