### PR TITLE
パーティクルシステムのグループ管理を名前ごとにするように設定。

### DIFF
--- a/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
@@ -359,7 +359,8 @@ void ParticleEmitter::GenerateParticles()
     if (useModelName_ == "")
         useModelName_ = "plane/plane.gltf";
 
-    ParticleSystem::GetInstance()->AddParticles(useModelName_, particles, settings, initParams_.textureHandle, initParams_.modifiers);
+    // groupnameには仮でエミッターの名前を入れている
+    ParticleSystem::GetInstance()->AddParticles(name_, useModelName_, particles, settings, initParams_.textureHandle, initParams_.modifiers);
 }
 
 void ParticleEmitter::InitJsonBinder()

--- a/Engine/Features/Effect/Emitter/ParticleEmitter.h
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.h
@@ -100,8 +100,8 @@ struct ParticleInitParamsForGenerator
 class ParticleEmitter
 {
 public:
-    ParticleEmitter() = default;
-    ~ParticleEmitter() = default;
+    ParticleEmitter() {};
+    ~ParticleEmitter() {};
 
     void Initialize(const std::string& _name);
     void Update(float _deltaTime);

--- a/Engine/Features/Effect/Manager/ParticleSystem.h
+++ b/Engine/Features/Effect/Manager/ParticleSystem.h
@@ -72,12 +72,12 @@ public:
 
     void SetModifierFactory(IParticleMoifierFactory* _factory);
 
-    void AddParticle(const std::string& _useModelName, Particle* _particle, ParticleRenderSettings _settings, uint32_t _textureHandle, std::vector<std::string> _modifiers);
-    void AddParticles(const std::string& _useModelName, std::vector<Particle*> _particles, ParticleRenderSettings _settings, uint32_t _textureHandle, std::vector<std::string> _modifiers);
+    void AddParticle(const std::string& _groupName,const std::string& _useModelName, Particle* _particle, ParticleRenderSettings _settings, uint32_t _textureHandle, std::vector<std::string> _modifiers);
+    void AddParticles(const std::string& _groupName,const std::string& _useModelName, std::vector<Particle*> _particles, ParticleRenderSettings _settings, uint32_t _textureHandle, std::vector<std::string> _modifiers);
 
 
     void ClearParticles();
-    void ClearParticles(const std::string& _useModelName);
+    void ClearParticles(const std::string& _groupName);
 
     void SetCamera(Camera* _camera) { camera_ = _camera; }
 
@@ -118,6 +118,7 @@ private:
 
     struct ParticleGroup
     {
+        ParticleKey key;
         Model* model = nullptr;
         std::list<Particle*> particles;
         uint32_t srvIndex = 0;
@@ -129,7 +130,7 @@ private:
         ParticleForGPU* mappedInstanceBuffer = nullptr;
     };
 
-    std::map<ParticleKey, ParticleGroup> particles_;
+    std::map<std::string, ParticleGroup> particles_;
 
     std::map<PSOFlags, ID3D12PipelineState*> psoMap_;
     ID3D12RootSignature* rootSignature_;

--- a/Engine/System/Time/Stopwatch.cpp
+++ b/Engine/System/Time/Stopwatch.cpp
@@ -1,5 +1,7 @@
 #include "Stopwatch.h"
 
+#include <Debug/ImGuiManager.h>
+
 Stopwatch::Stopwatch(bool _useGameTime, const std::string& _channelName) :
     useGameTime_(_useGameTime),
     channelName_(_channelName),
@@ -43,5 +45,35 @@ void Stopwatch::Update()
     {
         elapsedTime_ += Time::GetDeltaTime<double>();
     }
+}
+
+void Stopwatch::ShowDebugWindow()
+{
+#ifdef _DEBUG
+
+    ImGui::PushID(this);
+
+    if (ImGui::Button("Start"))
+    {
+        Start();
+    }
+    if (ImGui::Button("Stop"))
+    {
+        Stop();
+    }
+    if (ImGui::Button("Resume"))
+    {
+        Resume();
+    }
+    if (ImGui::Button("Reset"))
+    {
+        Reset();
+    }
+
+    ImGui::Text("Elapsed Time: %.2f", elapsedTime_);
+
+    ImGui::PopID();
+
+#endif // _DEBUG
 }
 

--- a/Engine/System/Time/Stopwatch.h
+++ b/Engine/System/Time/Stopwatch.h
@@ -43,10 +43,9 @@ public:
     /// </summary>
     template<typename T>
     T GetElapsedTime() const { return static_cast<T>(elapsedTime_); }
-    
 
 
-    float GetElapsedTime() const;
+    void ShowDebugWindow();
 
 private:
 


### PR DESCRIPTION
groupネームはエミッターの名前
パーティクルシステムのグループ管理を強化

`ParticleEmitter` と `ParticleSystem` のメソッドを修正し、パーティクルの追加やクリア処理にグループ名を使用するように変更しました。これにより、パーティクルの管理がより柔軟になりました。また、`Stopwatch` クラスにデバッグウィンドウを表示する機能を追加しました。