### PR TITLE
パーティクルシステムの設定とJSON管理の改善

### DIFF
--- a/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
@@ -365,7 +365,7 @@ void ParticleEmitter::GenerateParticles()
 
 void ParticleEmitter::InitJsonBinder()
 {
-    jsonBinder_ = std::make_unique<JsonBinder>(name_, "Resources/Effect/Emitters/");
+    jsonBinder_ = std::make_unique<JsonBinder>(name_, "Resources/data/Effect/Emitters/");
 
     jsonBinder_->RegisterVariable("offset", &offset_);
     jsonBinder_->RegisterVariable("shape", reinterpret_cast<uint32_t*>(&shape_));
@@ -377,7 +377,7 @@ void ParticleEmitter::InitJsonBinder()
     jsonBinder_->RegisterVariable("lifeTime", &lifeTime);
 
     jsonBinder_->RegisterVariable("position", &position_);
-    jsonBinder_->RegisterVariable("rotation", &rotation_);
+    jsonBinder_->RegisterVariable("rotation", &rotation_); // TODO
     jsonBinder_->RegisterVariable("boxSize", &boxSize_);
     jsonBinder_->RegisterVariable("sphereRadius", &sphereRadius_);
 

--- a/Engine/Features/Effect/Manager/ParticleSystem.cpp
+++ b/Engine/Features/Effect/Manager/ParticleSystem.cpp
@@ -234,8 +234,29 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
     }
     else
     {
-        it->second.particles.insert(it->second.particles.end(), _particles.begin(), _particles.end());
+        auto& group = it->second;
+
+        group.particles.insert(it->second.particles.end(), _particles.begin(), _particles.end());
+        group.key = key;
         particles_[_groupName].textureHandle = _textureHandle;
+
+
+        group.model = ModelManager::GetInstance()->FindSameModel(_useModelName);
+        if (group.model == nullptr)
+            throw std::runtime_error("Modelname '" + _useModelName + "'  が無効です。");
+
+        PSOFlags psoFlags = _settings.GetPSOFlags();
+        psoFlags |= PSOFlags::Type_Particle;
+
+        // PSOFlagsが未登録の場合は登録する
+        if (!psoMap_.contains(psoFlags))
+            psoMap_[psoFlags] = PSOManager::GetInstance()->GetPipeLineStateObject(psoFlags).value();
+
+        group.psoIndex = psoFlags;
+        group.textureHandle = _textureHandle;
+
+        particles_[_groupName] = group;
+
     }
 
     // モディファイアの登録

--- a/Engine/Features/Json/Loader/JsonLoader.h
+++ b/Engine/Features/Json/Loader/JsonLoader.h
@@ -3,6 +3,7 @@
 #include <Math/Vector/Vector2.h>
 #include <Math/Vector/Vector3.h>
 #include <Math/Vector/Vector4.h>
+#include <Math/Quaternion/Quaternion.h>
 #include <Debug/Debug.h>
 #include <string>
 #include <vector>
@@ -12,7 +13,7 @@
 
 using json = nlohmann::json;
 
-using ValueVariant = std::variant<int32_t, uint32_t, float, Vector2, Vector3, Vector4, std::string>;
+using ValueVariant = std::variant<int32_t, uint32_t, float, Vector2, Vector3, Vector4,Quaternion, std::string>;
 class JsonLoader {
 
 public:
@@ -89,6 +90,7 @@ void JsonLoader::GetValue(std::string _gName, std::string _vName, T& _v)
                        std::is_same_v<T, Vector2> ||
                        std::is_same_v<T, Vector3> ||
                        std::is_same_v<T, Vector4> ||
+                       std::is_same_v<T, Quaternion> ||
                        std::is_same_v<T, std::string>)
     {
         _v = std::get<T>(values_[_gName][_vName][0]);
@@ -122,7 +124,8 @@ void JsonLoader::GetValue(std::string _gName, std::string _vName, std::vector<T>
                        std::is_same_v<T, Vector2> ||
                        std::is_same_v<T, Vector3> ||
                        std::is_same_v<T, Vector4> ||
-                       std::is_same_v<T, std::string>)
+        std::is_same_v<T, Vector4> ||
+        std::is_same_v<T, std::string>)
     {
         std::vector<T> vec;
         for (auto& v : values_[_gName][_vName])
@@ -157,7 +160,8 @@ void JsonLoader::GetValue(std::string _gName, std::string _vName, std::list<T>& 
                        std::is_same_v<T, Vector2> ||
                        std::is_same_v<T, Vector3> ||
                        std::is_same_v<T, Vector4> ||
-                       std::is_same_v<T, std::string>)
+        std::is_same_v<T, Vector4> ||
+        std::is_same_v<T, std::string>)
     {
         std::list<T> list;
         for (auto& v : values_[_gName][_vName])

--- a/Sample/Resources/Data/Effect/Emitters/test.json
+++ b/Sample/Resources/Data/Effect/Emitters/test.json
@@ -151,6 +151,75 @@
             "y": 0.0,
             "z": 0.0
         },
+        "qe_keyFrames": [
+            {
+                "easingType": 0,
+                "isDelete": false,
+                "isSelect": false,
+                "time": 0.0,
+                "value": {
+                    "type": "class Quaternion",
+                    "value": {
+                        "w": 0.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    }
+                }
+            },
+            {
+                "easingType": 28,
+                "isDelete": false,
+                "isSelect": false,
+                "time": 0.6000000238418579,
+                "value": {
+                    "type": "class Quaternion",
+                    "value": {
+                        "w": 0.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    }
+                }
+            },
+            {
+                "easingType": 0,
+                "isDelete": false,
+                "isSelect": false,
+                "time": 2.299999952316284,
+                "value": {
+                    "type": "class Quaternion",
+                    "value": {
+                        "w": 47.0,
+                        "x": 31.0,
+                        "y": 0.0,
+                        "z": -11.0
+                    }
+                }
+            },
+            {
+                "easingType": 24,
+                "isDelete": false,
+                "isSelect": false,
+                "time": 3.5,
+                "value": {
+                    "type": "class Quaternion",
+                    "value": {
+                        "w": 0.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "z": 0.0
+                    }
+                }
+            }
+        ],
+        "qe_variableType": 5,
+        "rotation": {
+            "w": 1.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+        },
         "shape": 0,
         "size_Max": 2.0,
         "size_Min": 0.5,

--- a/Sample/SampleScene.cpp
+++ b/Sample/SampleScene.cpp
@@ -79,8 +79,8 @@ void SampleScene::Initialize()
     test_ = std::make_unique<ObjectModel>("triangle");
     test_->Initialize(triangle->Generate("triangle"));
 
-    emitter_ = std::make_unique<ParticleEmitter>();
-    emitter_->Initialize("test");
+    //emitter_ = std::make_unique<ParticleEmitter>();
+    //emitter_->Initialize("test");
 
     ParticleSystem::GetInstance()->SetCamera(&SceneCamera_);
 }
@@ -113,7 +113,7 @@ void SampleScene::Update()
     if (play)
         testColor_= sequence_->GetValue<Vector4>("color");
 
-    emitter_->ShowDebugWindow();
+    //emitter_->ShowDebugWindow();
 
 
 #endif // _DEBUG


### PR DESCRIPTION
ParticleEmitter.cppの`InitJsonBinder`メソッドで、`jsonBinder_`の初期化パスを変更し、`rotation`変数の登録にTODOコメントを追加しました。 ParticleSystem.cppの`AddParticles`メソッドで、パーティクル追加処理を修正し、モデル取得とエラーチェックを追加しました。 JsonLoader.hで`ValueVariant`に`Quaternion`を追加し、`GetValue`メソッドの条件を更新しました。 test.jsonでは、`modifiers`配列を空にし、`qe_keyFrames`の内容を削除、`speed_Value`と`useModelName`を変更しました。 SampleScene.cppで`ParticleEmitter`の初期化をコメントアウトし、`ShowDebugWindow`の呼び出しもコメントアウトしました。 imgui.iniのウィンドウ設定を変更し、新しいJSONオブジェクトをtest.jsonに追加しました。