### PR TITLE
.gitignoreにcopybat.batを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/copybat.bat


### PR DESCRIPTION
FodyWeavers.xsdとcopybat.batを.gitignoreに追加し、これらのファイルがGitの管理対象から除外されるようにしました。