### PR TITLE
キャッシュ機能の追加と有効フラグの設定

### DIFF
--- a/Engine/Math/BezierCurve3D.cpp
+++ b/Engine/Math/BezierCurve3D.cpp
@@ -273,6 +273,7 @@ std::vector<Vector3> BezierCurve3D::GenerateCurvePoints() const
 
     // 計算結果をキャッシュに保存
     cachedPoints_ = points;
+    isCacheValid_ = true;
 
     return points;
 }
@@ -396,6 +397,7 @@ std::vector<Vector3> BezierCurve3D::GenerateEquallySpacedPoints(int _numPoints) 
 
     // 計算結果をキャッシュに保存
     cachedEquallySpacedPoints_ = equallySpacedPoints;
+    isCacheValid_ = true;
 
     return equallySpacedPoints;
 }
@@ -542,6 +544,7 @@ std::vector<float> BezierCurve3D::GenerateEquallySpacedTValues(int _numPoints) c
 
     // 計算結果をキャッシュに保存
     cachedEquallySpacedTValues_ = tValues;
+    isCacheValid_ = true;
 
     return tValues;
 }


### PR DESCRIPTION
`BezierCurve3D::GenerateCurvePoints`、`GenerateEquallySpacedPoints`、および `GenerateEquallySpacedTValues` 関数において、計算結果をキャッシュするためのコードを追加しました。各関数の最後に `isCacheValid_ = true;` を設定し、キャッシュが有効であることを示すフラグを追加しました。これにより、計算結果の再利用が可能になり、パフォーマンスの向上が期待されます。