### PR TITLE
PointLightの影落とし適用

### DIFF
--- a/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
@@ -573,21 +573,22 @@ void PSOManager::CreatePSOForModel(PSOFlags _flags)
     shadowMapRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
     shadowMapRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
+
+    D3D12_DESCRIPTOR_RANGE PLShadowMapRange[1] = {};
+    PLShadowMapRange[0].BaseShaderRegister = 2;  // t2 にバインド
+    PLShadowMapRange[0].NumDescriptors = 1;
+    PLShadowMapRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    PLShadowMapRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
     D3D12_DESCRIPTOR_RANGE enviromentMapRange[1] = {};
-    enviromentMapRange[0].BaseShaderRegister = 2;  // t2 にバインド
-    enviromentMapRange[0].NumDescriptors = 1; 
+    enviromentMapRange[0].BaseShaderRegister = 3;  // t3 にバインド
+    enviromentMapRange[0].NumDescriptors = 1;
     enviromentMapRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
     enviromentMapRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
-    //D3D12_DESCRIPTOR_RANGE PLShadowMapRange[1] = {};
-    //PLShadowMapRange[0].BaseShaderRegister = 2;  // t2 にバインド
-    //PLShadowMapRange[0].NumDescriptors = 32 * 6;
-    //PLShadowMapRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-    //PLShadowMapRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
-
 
     //RootParameter作成
-    D3D12_ROOT_PARAMETER rootParameters[8] = {};
+    D3D12_ROOT_PARAMETER rootParameters[9] = {};
 
     //カメラ
     rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
@@ -627,16 +628,16 @@ void PSOManager::CreatePSOForModel(PSOFlags _flags)
     rootParameters[6].DescriptorTable.NumDescriptorRanges = _countof(shadowMapRange);
 
     // PLシャドウマップ
-   /* rootParameters[7].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
-    rootParameters[7].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-    rootParameters[7].DescriptorTable.pDescriptorRanges = PLShadowMapRange;
-    rootParameters[7].DescriptorTable.NumDescriptorRanges = _countof(PLShadowMapRange);*/
-
-    // 環境マップ用のテクスチャ
     rootParameters[7].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
     rootParameters[7].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-    rootParameters[7].DescriptorTable.pDescriptorRanges = enviromentMapRange;
-    rootParameters[7].DescriptorTable.NumDescriptorRanges = _countof(enviromentMapRange);
+    rootParameters[7].DescriptorTable.pDescriptorRanges = PLShadowMapRange;
+    rootParameters[7].DescriptorTable.NumDescriptorRanges = _countof(PLShadowMapRange);
+
+    // 環境マップ用のテクスチャ
+    rootParameters[8].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    rootParameters[8].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+    rootParameters[8].DescriptorTable.pDescriptorRanges = enviromentMapRange;
+    rootParameters[8].DescriptorTable.NumDescriptorRanges = _countof(enviromentMapRange);
 
     
 

--- a/Engine/Features/Model/SkyBox.h
+++ b/Engine/Features/Model/SkyBox.h
@@ -25,7 +25,7 @@ public:
     void SetTexture(const std::string& _name);
     void SetTexture(uint32_t _handle);
 
-    void QueueCmdCubeTexture(uint32_t _index = 7) const;
+    void QueueCmdCubeTexture(uint32_t _index = 8) const;
 
 private:
     void UpdateWorldTransform();

--- a/Engine/Framework/Framework.cpp
+++ b/Engine/Framework/Framework.cpp
@@ -43,6 +43,9 @@ void Framework::Initialize()
     rtvManager_ = RTVManager::GetInstance();
     rtvManager_->Initialize(dxCommon_->GetBackBufferSize(), WinApp::kWindowWidth_, WinApp::kWindowHeight_);
 
+#ifdef _DEBUG
+    ImGuiDebugManager::GetInstance()->Initialize();
+#endif
 
     PSOManager::GetInstance()->Initialize();
 
@@ -85,9 +88,6 @@ void Framework::Initialize()
 
 
 
-#ifdef _DEBUG
-    ImGuiDebugManager::GetInstance()->Initialize();
-#endif
 
 }
 

--- a/Sample/Resources/Shader/Object3d.hlsli
+++ b/Sample/Resources/Shader/Object3d.hlsli
@@ -25,6 +25,8 @@ struct DirectionalLight
 
     int isHalf;
     int castShadow;
+    float shadowFactor;
+    float pad;
 };
 
 struct PointLight
@@ -38,6 +40,9 @@ struct PointLight
     float decay;
     int isHalf;
     int castShadow;
+    
+    float shadowFactor;
+    float3 pad;
 
     float4x4 lightVP[6];
 };
@@ -58,7 +63,8 @@ struct SpotLight
     int isHalf;
 
     int castShadow;
-    float3 pad;
+    float shadowFactor;
+    float2 pad;
 
     float4x4 lightVP;
 };

--- a/Sample/Resources/Shader/PointLightShadowMap.hlsl
+++ b/Sample/Resources/Shader/PointLightShadowMap.hlsl
@@ -32,14 +32,21 @@ cbuffer TransformationMatrix : register(b0)
 struct PointLight
 {
     float4 color;
+
     float3 position;
     float intensity;
+
     float radius;
     float decay;
     int isHalf;
+    int castShadow;
+    
+    float shadowFactor;
+    float3 pad;
 
     float4x4 lightVP[6];
 };
+
 
 cbuffer gLightGroup : register(b1)
 {

--- a/Sample/SampleScene.cpp
+++ b/Sample/SampleScene.cpp
@@ -73,6 +73,12 @@ void SampleScene::Initialize()
     lights_ = std::make_shared<LightGroup>();
     lights_->Initialize();
 
+    //auto pl = std::make_shared<PointLightComponent>();
+    //lights_->AddPointLight("PointLight", pl);
+
+
+    LightingSystem::GetInstance()->SetActiveGroup(lights_);
+
     sequence_ = std::make_unique<AnimationSequence>("test");
     sequence_->Initialize("Resources/Data/");
 
@@ -152,7 +158,6 @@ void SampleScene::Update()
 
 
 #endif // _DEBUG
-    LightingSystem::GetInstance()->SetActiveGroup(lights_);
 
     for (auto& col : colliders_)
     {
@@ -203,7 +208,7 @@ void SampleScene::Draw()
 
     //oModel_->Draw(&SceneCamera_, testColor_);
     //oModel2_->Draw(&SceneCamera_, 0 ,{ 1, 1, 1, 1 });
-    //plane_->Draw(&SceneCamera_, { 1,1,1,1 });
+    plane_->Draw(&SceneCamera_, { 1,1,1,1 });
 
     ////aModel_->Draw(&SceneCamera_, { 1,1,1,1 });
 
@@ -222,6 +227,10 @@ void SampleScene::Draw()
 void SampleScene::DrawShadow()
 {
 
+    for (auto& model : models_)
+    {
+        model->DrawShadow(&SceneCamera_, 0);
+    }
     //oModel_->DrawShadow(&SceneCamera_, 0);
     //oModel2_->DrawShadow(&SceneCamera_, 1);
     //aModel_->DrawShadow(&SceneCamera_, 2);


### PR DESCRIPTION
CreatePSOForModel関数に新しいデスクリプタレンジを追加し、ルートパラメータの数を増加させました。環境マップのベースシェーダーレジスタが変更され、PLシャドウマップの設定が修正されました。

SkyBox.hでは、QueueCmdCubeTexture関数のデフォルト引数を変更しました。

Framework.cppのInitialize関数にデバッグビルド時のImGuiDebugManagerの初期化を追加しました。

Object3d.PS.hlslでは、環境テクスチャの登録を変更し、ComputePointLightShadow関数を追加しました。CalculatePointLighting関数も修正され、シャドウファクターを考慮するようになりました。

Object3d.hlsliでは、DirectionalLight、PointLight、SpotLight構造体にshadowFactorを追加し、ポイントライトの構造体にpositionとradiusを追加しました。

SampleScene.cppでは、ポイントライトコンポーネントの追加をコメントアウトし、Draw関数内でのplaneの描画を有効化しました。また、DrawShadow関数を追加し、モデルのシャドウ描画を行うようにしました。