### PR TITLE
シャドウアクネを直したかった できなかった

### DIFF
--- a/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
@@ -541,13 +541,13 @@ void PSOManager::CreatePSOForModel(PSOFlags _flags)
 
     // pointLight用のサンプラ
     staticSamplers[2].Filter = D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT; // 比較用フィルタ
-    staticSamplers[2].AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP; // 境界外を無効化
-    staticSamplers[2].AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    staticSamplers[2].AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+    staticSamplers[2].AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER; // 境界外を無効化
+    staticSamplers[2].AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+    staticSamplers[2].AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
     staticSamplers[2].BorderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE; // 影の外は光が当たる
     staticSamplers[2].ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL; // 深度比較
     staticSamplers[2].MaxLOD = D3D12_FLOAT32_MAX;
-    staticSamplers[2].ShaderRegister = 2; // s1
+    staticSamplers[2].ShaderRegister = 2; // s2
     staticSamplers[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 
 
@@ -569,7 +569,7 @@ void PSOManager::CreatePSOForModel(PSOFlags _flags)
 
     D3D12_DESCRIPTOR_RANGE shadowMapRange[1] = {};
     shadowMapRange[0].BaseShaderRegister = 1;  // t1 にバインド
-    shadowMapRange[0].NumDescriptors = 1; 
+    shadowMapRange[0].NumDescriptors = 1;
     shadowMapRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
     shadowMapRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
@@ -639,7 +639,7 @@ void PSOManager::CreatePSOForModel(PSOFlags _flags)
     rootParameters[8].DescriptorTable.pDescriptorRanges = enviromentMapRange;
     rootParameters[8].DescriptorTable.NumDescriptorRanges = _countof(enviromentMapRange);
 
-    
+
 
     descriptionRootSignature.pParameters = rootParameters;
     descriptionRootSignature.NumParameters = _countof(rootParameters);         // 配列の長さ

--- a/Engine/Features/Light/Group/LightGroup.cpp
+++ b/Engine/Features/Light/Group/LightGroup.cpp
@@ -224,6 +224,7 @@ void LightGroup::ImGui()
 void LightGroup::DrawDirectionalLightImGui()
 {
 #ifdef _DEBUG
+    bool isDirty = false;
     if (ImGui::CollapsingHeader("Directional Light")) {
         if (!directionalLight_) {
             if (ImGui::Button("Create Directional Light")) {
@@ -241,11 +242,12 @@ void LightGroup::DrawDirectionalLightImGui()
         Vector3 dir = data.direction;
         if (ImGui::DragFloat3("Direction", &dir.x, 0.01f)) {
             directionalLight_->SetDirection(dir); // Normalized internally
+            isDirty = true;
         }
 
-        ImGui::DragFloat("Intensity", &data.intensity, 0.01f, 0.0f, 10.0f);
+        isDirty|=ImGui::DragFloat("Intensity", &data.intensity, 0.01f, 0.0f, 10.0f);
 
-        ImGui::DragFloat("Shadow Factor", &data.shadowFactor, 0.01f, 0.0f, 1.0f);
+        isDirty |= ImGui::DragFloat("Shadow Factor", &data.shadowFactor, 0.01f, 0.0f, 1.0f);
 
         bool isHalf = data.isHalf != 0;
         if (ImGui::Checkbox("Half Lambert", &isHalf)) {
@@ -256,6 +258,12 @@ void LightGroup::DrawDirectionalLightImGui()
         if (ImGui::Checkbox("Cast Shadow", &castShadow)) {
             directionalLight_->SetCastShadow(castShadow);
         }
+
+        if(isDirty)
+        {
+            directionalLight_->UpdateViewProjection(shadowMapSize_);
+        }
+
     }
 #endif // _DEBUG
 

--- a/Engine/Features/Light/Point/PointLight.cpp
+++ b/Engine/Features/Light/Point/PointLight.cpp
@@ -39,6 +39,8 @@ void PointLightComponent::CreateShadowMaps(uint32_t shadowMapSize)
     // 6面分のシャドウマップを作成
     std::string mapName = name_ + "_ShadowMap";
 
+    shadowMapSize = 4096;
+
     uint32_t handle =
         RTVManager::GetInstance()->CreateCubemapRenderTarget(
             mapName,

--- a/Engine/Features/Light/System/LightingSystem.cpp
+++ b/Engine/Features/Light/System/LightingSystem.cpp
@@ -31,15 +31,11 @@ void LightingSystem::Initialize()
     *shadowSpotLightData_ = {}; // 0で初期化
 
     // シャドウマップのサイズを設定
-    shadowMapSize_ = 256;
+    shadowMapSize_ = 128;
     if (LightGroup::GetShadowMapSize() != shadowMapSize_) {
         LightGroup::SetShadowMapSize(shadowMapSize_);
     }
 
-}
-
-void LightingSystem::Update()
-{
 }
 
 void LightingSystem::QueueGraphicsCommand(ID3D12GraphicsCommandList* _commandList, uint32_t _index)

--- a/Engine/PointLightShadowMap.hlsl
+++ b/Engine/PointLightShadowMap.hlsl
@@ -33,11 +33,17 @@ cbuffer TransformationMatrix : register(b0)
 struct PointLight
 {
     float4 color;
+
     float3 position;
     float intensity;
+
     float radius;
     float decay;
     int isHalf;
+    int castShadow;
+
+    float shadowFactor;
+    float3 pad;
 
     float4x4 lightVP[6];
 };

--- a/Sample/Resources/Shader/Object3d.PS.hlsl
+++ b/Sample/Resources/Shader/Object3d.PS.hlsl
@@ -94,7 +94,7 @@ float ComputePointLightShadow(int lightIndex, float3 worldPos, PointLight _PL)
     ).r;
 
     // シャドウバイアスを考慮
-    float bias = 0.005;
+    float bias = 0.001;
     float shadow = currentDepth > closestDepth + bias ? _PL.shadowFactor : 1.0;
 
 
@@ -119,7 +119,7 @@ PixelShaderOutput main(VertexShaderOutput _input)
     // シャドウファクターを適用したライティング
     float3 directionalLight = CalculateDirectionalLighting(_input, toEye, textureColor) * shadowFactor;
     float3 pointLight = CalculateLightingWithMultiplePointLights(_input, toEye, textureColor);
-    float3 spotLightcColor = CalculateLightingWithMultipleSpotLights(_input, toEye, textureColor) * shadowFactor;
+    float3 spotLightcColor = CalculateLightingWithMultipleSpotLights(_input, toEye, textureColor);
 
     float3 envColor = CalculateEnViromentColor(_input, worldPosition);
 

--- a/Sample/Resources/Shader/PointLightShadowMap.hlsl
+++ b/Sample/Resources/Shader/PointLightShadowMap.hlsl
@@ -40,7 +40,7 @@ struct PointLight
     float decay;
     int isHalf;
     int castShadow;
-    
+
     float shadowFactor;
     float3 pad;
 


### PR DESCRIPTION
PLがdepth参照していないことにきがついた

PSOとシャドウマップの設定を最適化

PSOManager.cppでサンプラーのアドレスモードを変更し、シャドウマップのサイズを最適化しました。 LightGroup.cppに`isDirty`フラグを追加し、方向や強度の変更時にビュー投影を更新する処理を実装。 PointLight.cppで高解像度のシャドウマップを生成するためにサイズを4096に設定。
LightingSystem.cppでシャドウマップのサイズを128に変更し、関連する設定を更新。
PointLightShadowMap.hlslに`shadowFactor`を追加し、Object3d.PS.hlslでシャドウバイアスを調整。