### PR TITLE
深度設定の強化とPSOフラグの追加

### DIFF
--- a/Engine/Core/DXCommon/PSOManager/PSOManager.h
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.h
@@ -33,6 +33,17 @@ enum class PSOFlags
     Cull_None				= 1 << 20,
     Cull_Front				= 1 << 21,
     Cull_Back				= 1 << 22,
+
+    Depth_Enable            = 1 << 23,
+    Depth_Disable           = 1 << 24,
+    Depth_Mask_All          = 1 << 25,
+    Depth_Mask_Zero         = 1 << 26,
+    Depth_Func_LessEqual    = 1 << 27,
+    Depth_Func_Always       = 1 << 28,
+    // TODO 項目ごとに分けるべき
+
+    Depth_mAll_fLEqual = Depth_Enable | Depth_Mask_All | Depth_Func_LessEqual,
+    Depth_mZero_fLEqual = Depth_Enable | Depth_Mask_Zero | Depth_Func_LessEqual
 };
 
 PSOFlags SetBlendMode(PSOFlags _flag, PSOFlags _mode);
@@ -101,6 +112,12 @@ PSOFlags::Blend_Sub | PSOFlags::Blend_Multiply | PSOFlags::Blend_Screen;
 constexpr PSOFlags CullMask =
 PSOFlags::Cull_Back | PSOFlags::Cull_Front | PSOFlags::Cull_None;
 
+constexpr PSOFlags DepthMask =
+PSOFlags::Depth_Enable | PSOFlags::Depth_Disable | PSOFlags::Depth_Mask_All
+| PSOFlags::Depth_Mask_Zero | PSOFlags::Depth_Func_LessEqual
+| PSOFlags::Depth_Func_Always;
+
+
 
 #pragma endregion
 #pragma endregion
@@ -162,6 +179,7 @@ private:
 
 	D3D12_BLEND_DESC GetBlendDesc(PSOFlags _flag);
     D3D12_RASTERIZER_DESC GetRasterizerDesc(PSOFlags _flag);
+    D3D12_DEPTH_STENCIL_DESC GetDepthStencilDesc(PSOFlags _flag);
 
     size_t GetType(PSOFlags _flag);
 	PSOFlags GetBlendMode(PSOFlags _flag);

--- a/Engine/Features/Effect/Manager/ParticleSystem.cpp
+++ b/Engine/Features/Effect/Manager/ParticleSystem.cpp
@@ -164,7 +164,7 @@ void ParticleSystem::AddParticle(const std::string& _groupName, const std::strin
         group.model = ModelManager::GetInstance()->FindSameModel(_useModelName);
 
         PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle;
+        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
 
         // PSOFlagsが未登録の場合は登録する
         if (!psoMap_.contains(psoFlags))
@@ -221,7 +221,7 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
             throw std::runtime_error("Modelname '" + _useModelName + "'  が無効です。");
 
         PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle;
+        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
 
         // PSOFlagsが未登録の場合は登録する
         if (!psoMap_.contains(psoFlags))
@@ -246,7 +246,7 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
             throw std::runtime_error("Modelname '" + _useModelName + "'  が無効です。");
 
         PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle;
+        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
 
         // PSOFlagsが未登録の場合は登録する
         if (!psoMap_.contains(psoFlags))

--- a/Engine/Features/LineDrawer/LineDrawer.cpp
+++ b/Engine/Features/LineDrawer/LineDrawer.cpp
@@ -13,7 +13,8 @@ LineDrawer* LineDrawer::GetInstance()
 
 void LineDrawer::Initialize()
 {
-    psoFlags_ = PSOFlags::Type_LineDrawer | PSOFlags::Blend_Normal | PSOFlags::Cull_None;
+    psoFlags_ = PSOFlags::Type_LineDrawer | PSOFlags::Blend_Normal | PSOFlags::Cull_None |
+        PSOFlags::Depth_mZero_fLEqual;
 
     index = 0u;
     color_ = { 0.0f,0.0f,0.0f,1.0f };

--- a/Engine/Features/Model/Manager/ModelManager.cpp
+++ b/Engine/Features/Model/Manager/ModelManager.cpp
@@ -12,7 +12,8 @@ ModelManager* ModelManager::GetInstance()
 
 void ModelManager::Initialize()
 {
-    psoFlags_ = PSOFlags::Type_Model | PSOFlags::Blend_Normal | PSOFlags::Cull_Back;
+    psoFlags_ = PSOFlags::Type_Model | PSOFlags::Blend_Normal | PSOFlags::Cull_Back | PSOFlags::Depth_mAll_fLEqual;
+    psoFlagsForAlpha_ = PSOFlags::Type_Model | PSOFlags::Blend_Normal | PSOFlags::Cull_Back | PSOFlags::Depth_mZero_fLEqual;
 
 
     /// PSOを取得
@@ -26,6 +27,13 @@ void ModelManager::Initialize()
     // 生成されているか確認
     assert(rootSignature.has_value() && rootSignature != nullptr);
     rootSignature_ = rootSignature.value();
+
+    auto psoAlpha = PSOManager::GetInstance()->GetPipeLineStateObject(psoFlagsForAlpha_);
+    // PSOが生成されているか確認
+    assert(psoAlpha.has_value() && psoAlpha != nullptr);
+    graphicsPipelineStateForAlpha_ = psoAlpha.value();
+
+
  }
 
 void ModelManager::PreDrawForObjectModel() const
@@ -34,6 +42,16 @@ void ModelManager::PreDrawForObjectModel() const
 
     commandList->SetGraphicsRootSignature(rootSignature_);
     commandList->SetPipelineState(graphicsPipelineState_);
+
+    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+}
+
+void ModelManager::PreDrawForAlphaObjectModel() const
+{
+    auto commandList = DXCommon::GetInstance()->GetCommandList();
+
+    commandList->SetGraphicsRootSignature(rootSignature_);
+    commandList->SetPipelineState(graphicsPipelineStateForAlpha_);
 
     commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 }

--- a/Engine/Features/Model/Manager/ModelManager.h
+++ b/Engine/Features/Model/Manager/ModelManager.h
@@ -18,7 +18,7 @@ public:
 
     void Initialize();
     void PreDrawForObjectModel() const;
-
+    void PreDrawForAlphaObjectModel() const;
 
     Model* FindSameModel(const std::string& _name);
     Model* Create(const std::string& _name);
@@ -29,7 +29,11 @@ private:
     ID3D12RootSignature* rootSignature_ = {};
     ID3D12PipelineState* graphicsPipelineState_ = {};
 
+    ID3D12PipelineState* graphicsPipelineStateForAlpha_ = {};
+
+
     PSOFlags psoFlags_ = {};
+    PSOFlags psoFlagsForAlpha_{};
 
 
     ModelManager() = default;

--- a/Engine/Features/Model/ObjectModel.cpp
+++ b/Engine/Features/Model/ObjectModel.cpp
@@ -64,13 +64,15 @@ void ObjectModel::Draw(const Camera* _camera, const Vector4& _color)
     objectColor_->SetColor(_color);
 
     auto lightGroup = LightingSystem::GetInstance()->GetLightGroup();
-
-    auto pointLights = lightGroup->GetAllPointLights();
-    if (!pointLights.empty())
+    if(lightGroup)
     {
-        auto handles = pointLights[0]->GetShadowMapHandles();
-        uint32_t handle = handles[0];
-        RTVManager::GetInstance()->QueuePointLightShadowMapToSRV(handle, 7);
+        auto pointLights = lightGroup->GetAllPointLights();
+        if (!pointLights.empty())
+        {
+            auto handles = pointLights[0]->GetShadowMapHandles();
+            uint32_t handle = handles[0];
+            RTVManager::GetInstance()->QueuePointLightShadowMapToSRV(handle, 7);
+        }
     }
 
     RTVManager::GetInstance()->GetRenderTexture("ShadowMap")->QueueCommandDSVtoSRV(6);

--- a/Engine/Features/Model/Primitive/Plane.cpp
+++ b/Engine/Features/Model/Primitive/Plane.cpp
@@ -4,12 +4,12 @@
 #include <Math/Vector/VectorFunction.h>
 #include <Math/Matrix/MatrixFunction.h>
 
-// 上向き板 いらんかも //TODO
+// z+向き板 いらんかも //TODO
 std::array<Vector3, 4> Plane::defaultVertices_ = {
-   Vector3(-1.0f, 0.0f, -1.0f ),
-   Vector3( 1.0f, 0.0f, -1.0f ),
-   Vector3( 1.0f, 0.0f,  1.0f ),
-   Vector3(-1.0f, 0.0f,  1.0f )
+   Vector3( 1.0f,  1.0f ,0.0f),
+   Vector3(-1.0f,  1.0f ,0.0f),
+   Vector3( 1.0f, -1.0f ,0.0f),
+   Vector3(-1.0f, -1.0f ,0.0f)
 };
 
 Model* Plane::Generate(const std::string& _name)
@@ -48,31 +48,28 @@ std::array<Vector3, 4> Plane::CalculateVertices()
 {
     std::array<Vector3, 4> vertices = defaultVertices_;
     normal_ = normal_.Normalize();
-    const Vector3 defaultNormal = { 0.0f, 0.0f, 1.0f };
+    const Vector3 defaultNormal = { 0.0f, 0.0f, -1.0f };
     Quaternion q = Quaternion::FromToRotation(defaultNormal, normal_);
     Matrix4x4 rotationMatrix = q.Normalize().ToMatrix();
 
     Vector4 halfSize = size_ * 0.5f;
 
-    // 正規化pivot（-1~1）を実際の座標に変換
-    Vector3 actualPivot = {
-        pivot_.x * halfSize.x,  // X軸のpivot位置
-        pivot_.y * halfSize.y,  // Y軸のpivot位置
-        0.0f
-    };
+    for (uint32_t i = 0; i < vertices.size(); ++i)
+    {
+        // 基準点を適用
+        vertices[i] -= pivot_;
 
-    vertices[0] = { -halfSize.x,   halfSize.y, 0.0f }; // 左上
-    vertices[1] = { halfSize.x,   halfSize.z, 0.0f }; // 右上
-    vertices[2] = { -halfSize.w,  -halfSize.y, 0.0f }; // 左下
-    vertices[3] = { halfSize.w,  -halfSize.z, 0.0f }; // 右下
+        // サイズを適用
+        vertices[i].x *= halfSize.x;
+        vertices[i].y *= halfSize.y;
+        vertices[i].z *= halfSize.z;
+
+    }
 
     for (uint32_t i = 0; i < vertices.size(); ++i)
     {
         // 回転を適用
         vertices[i] = Transform(vertices[i], rotationMatrix);
-
-        vertices[i] = vertices[i] + actualPivot;
-
     }
 
     return vertices;


### PR DESCRIPTION
PSOManagerに深度関連のフラグを追加し、PSOの初期化や作成時に深度ステンシル状態の設定を改善しました。新たにGetDepthStencilDescメソッドを追加し、PSOフラグの検証に深度フラグを含めました。ParticleSystem、LineDrawer、ModelManagerの初期化メソッドでも深度設定を考慮し、ObjectModelのDrawメソッドではポイントライトのシャドウマップ処理を改善しました。Planeクラスではデフォルトの頂点配列と法線の向きが変更され、頂点計算方法が改善されました。