### PR TITLE
パーティクルエミッターの位置計算を改善

### DIFF
--- a/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
@@ -299,9 +299,12 @@ void ParticleEmitter::GenerateParticles()
         }
 
         initParam.position;
-        Vector3 emitterWorldPos = offset_;
+        Vector3 emitterWorldPos = { 0,0,0 };
         if (parentTransform_)
-            emitterWorldPos += parentTransform_->GetWorldPosition();
+        {
+            //emitterWorldPos = parentTransform_->GetWorldPosition();
+            emitterWorldPos = Transform(offset_, parentTransform_->matWorld_);
+        }
         switch (shape_)
         {
         case EmitterShape::Box:
@@ -318,6 +321,7 @@ void ParticleEmitter::GenerateParticles()
             initParam.position.x = std::cosf(rad) * sphereOffset;
             initParam.position.y = RandomGenerator::GetInstance()->GetRandValue(-sphereOffset, sphereOffset);
             initParam.position.z = std::sinf(rad) * sphereOffset;
+            initParam.position += emitterWorldPos;
             break;
         }
         default:

--- a/Engine/Features/Effect/Emitter/ParticleEmitter.h
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.h
@@ -117,6 +117,9 @@ public:
 
     void GenerateParticles();
 
+    void SetParentTransform(WorldTransform* _parentTransform) { parentTransform_ = _parentTransform; }
+    void SetOffset(const Vector3& _offset) { offset_ = _offset; }
+
 private:
 
     void InitJsonBinder();

--- a/Engine/Features/Effect/Manager/ParticleSystem.cpp
+++ b/Engine/Features/Effect/Manager/ParticleSystem.cpp
@@ -89,10 +89,11 @@ void ParticleSystem::Update(float _deltaTime)
                 continue;
             }
 
-            Matrix4x4 affineMatrix = MakeScaleMatrix(particle->GetScale());
-            affineMatrix *= billboardMatrix;
-            affineMatrix *= MakeRotateMatrix(particle->GetRotation());
-            affineMatrix *= MakeTranslateMatrix(particle->GetPosition());
+            Matrix4x4 affineMatrix =
+                MakeScaleMatrix(particle->GetScale()) *
+                MakeRotateMatrix(particle->GetRotation()) *
+                billboardMatrix*
+                MakeTranslateMatrix(particle->GetPosition());
 
             particleList.mappedInstanceBuffer[particleList.instanceCount].worldMatrix = affineMatrix;
             particleList.mappedInstanceBuffer[particleList.instanceCount].color = particle->GetColor();


### PR DESCRIPTION
`ParticleEmitter::GenerateParticles` メソッドでの `emitterWorldPos` の初期化を変更し、親トランスフォームに基づく位置調整を行うようにしました。また、`ParticleEmitter` クラスに `SetParentTransform` と `SetOffset` メソッドを追加しました。さらに、`ParticleSystem::Update` メソッド内でアフィン行列の計算方法を簡潔にし、可読性を向上させました。