### PR TITLE
メモリ管理の改善とデバッグウィンドウの整理

### DIFF
--- a/Engine/Features/Collision/Manager/CollisionManager.cpp
+++ b/Engine/Features/Collision/Manager/CollisionManager.cpp
@@ -529,8 +529,9 @@ void CollisionManager::UpdateBroadPhase()
 
     std::list<Collider*> stac;
 
+    if(!colliders_.empty())
     // QuadTreeを使用して衝突ペアを取得
-    quadTree_->GetCollisionPair(0, potentialCollisions_, stac);
+        quadTree_->GetCollisionPair(0, potentialCollisions_, stac);
 
     for (auto dynamicCollider : colliders_)
     {

--- a/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
@@ -63,27 +63,25 @@ void ParticleEmitter::ShowDebugWindow()
 #ifdef _DEBUG
 
 
+    ImGui::PushID(this);
     {
-        if(ImGui::BeginTabItem(name_.c_str()))
+        if (ImGui::Button("Emit"))      GenerateParticles();
+        ImGui::SameLine();
+        if (ImGui::Button("Save"))
         {
+            jsonBinder_->Save();
+        }
 
-            if (ImGui::Button("Emit"))      GenerateParticles();
-            ImGui::SameLine();
-            if (ImGui::Button("Save"))
-            {
-                jsonBinder_->Save();
-            }
+        if (ImGui::CollapsingHeader("Emitter Settings"))
+        {
+            ImGui::Text("Emitter Name");
 
-            if (ImGui::CollapsingHeader("Emitter Settings"))
-            {
-                ImGui::Text("Emitter Name");
+            ImGui::BeginDisabled(1);
+            ImGui::InputText("##EmitterName", name_.data(), name_.size());
+            ImGui::EndDisabled();
 
-                ImGui::BeginDisabled(1);
-                ImGui::InputText("##EmitterName", name_.data(), name_.size());
-                ImGui::EndDisabled();
-
-                ImGui::Separator();
-                if (ImGui::TreeNode("Emitter Shape"))
+            ImGui::Separator();
+            if (ImGui::TreeNode("Emitter Shape"))
                 {
                     int* shapePtr = reinterpret_cast<int*>(&shape_);
 
@@ -106,162 +104,161 @@ void ParticleEmitter::ShowDebugWindow()
                         break;
                     }
                 }
-                if (ImGui::TreeNode("Emit Settings"))
-                {
-                    ImGui::InputInt("Emit count", reinterpret_cast<int*>(&emitCount_));
-                    ImGui::InputInt("Emit per second", reinterpret_cast<int*>(&emitPerSecond_));
-
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Time"))
-                {
-                    ImGui::DragFloat("Delay Time", &delayTime_, 0.01f);
-                    ImGui::DragFloat("Life Time", &lifeTime, 0.01f);
-                    ImGui::Checkbox("Loop", &isLoop_);
-
-                    ImGui::TreePop();
-                }
-
-                if (parentTransform_ != nullptr)
-                {
-                    if (ImGui::TreeNode("Emitter Offset"))
-                    {
-                        ImGui::DragFloat3("Offset", &offset_.x, 0.01f);
-                        ImGui::TreePop();
-                    }
-                }
-            }
-
-            if (ImGui::CollapsingHeader("Particle Init Params"))
+            if (ImGui::TreeNode("Emit Settings"))
             {
-                if (ImGui::TreeNode("Use Model"))
-                {
-                    ImGui::Text("ModelPath");
-                    ImGui::InputText("##ModelPath", modelPath_, 256);
-                    if (ImGui::Button("Apply##ModelPath"))
-                    {
-                        Model* model = Model::CreateFromFile(modelPath_);
-                        useModelName_ = modelPath_;
-                        strcpy_s(modelName_, 256, "");
-                    }
-                    ImGui::Separator();
-                    ImGui::Text("ModelName");
-                    ImGui::InputText("##ModelName", modelName_, 256);
-                    if (ImGui::Button("Apply##ModelName"))
-                    {
-                        Model* model = ModelManager::GetInstance()->FindSameModel(modelName_);
-                        if (model == nullptr)
-                        {
-                            throw std::runtime_error("Model not found");
-                        }
-                        else
-                        {
-                            useModelName_ = modelName_;
-                            strcpy_s(modelPath_, 256, "");
-                        }
-                    }
-                    ImGui::TreePop();
-                }
+                ImGui::InputInt("Emit count", reinterpret_cast<int*>(&emitCount_));
+                ImGui::InputInt("Emit per second", reinterpret_cast<int*>(&emitPerSecond_));
 
-                if (ImGui::TreeNode("Use Texture"))
-                {
-                    ImGui::Text("TextureRoot");
-                    ImGui::InputText("##TextureRoot", textureRoot_, 256);
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Time"))
+            {
+                ImGui::DragFloat("Delay Time", &delayTime_, 0.01f);
+                ImGui::DragFloat("Life Time", &lifeTime, 0.01f);
+                ImGui::Checkbox("Loop", &isLoop_);
 
-                    ImGui::Text("TexturePath");
-                    ImGui::InputText("##TexturePath", texturePath_, 256);
-                    if (ImGui::Button("Apply##TexturePath"))
-                    {
-                        initParams_.textureName = texturePath_;
-                        TextureManager::GetInstance()->Load(texturePath_, textureRoot_);
-                    }
-                    ImGui::TreePop();
-                }
-
-                if (ImGui::TreeNode("Billboard"))
-                {
-                    ImGui::Text("Billboard");
-                    ImGui::Checkbox("X", &initParams_.billboard[0]);            ImGui::SameLine();
-                    ImGui::Checkbox("Y", &initParams_.billboard[1]);            ImGui::SameLine();
-                    ImGui::Checkbox("Z", &initParams_.billboard[2]);
-                    ImGui::TreePop();
-                }
-
-                // RenderSetting
-                if (ImGui::TreeNode("Render Setting"))
-                {
-                    ImGui::Text("Blend Mode");
-                    ImGui::RadioButton("Normal", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Normal));
-                    ImGui::RadioButton("Add", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Add));
-                    ImGui::RadioButton("Sub", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Sub));
-                    ImGui::RadioButton("Mul", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Multiply));
-                    ImGui::RadioButton("Screen", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Screen));
-
-                    ImGui::Separator();
-
-                    ImGui::Checkbox("Cull Back", &cullBack_);
-
-                    ImGui::TreePop();
-                }
-
-                if (ImGui::TreeNode("Life Time"))
-                {
-                    DebugWindowForLifeTime();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Position"))
-                {
-                    DebugWindowForPosition();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Size"))
-                {
-                    DebugWindowForSize();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Direction"))
-                {
-                    DebugWindowForDirection();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Speed"))
-                {
-                    DebugWindowForSpeed();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Rotation"))
-                {
-                    DebugWindowForRotation();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Deceleration"))
-                {
-                    DebugWindowForDeceleration();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Color"))
-                {
-                    DebugWindowForColor();
-                    ImGui::TreePop();
-                }
-                if (ImGui::TreeNode("Modifiers"))
-                {
-                    DebugWindowForModifier();
-                    ImGui::TreePop();
-                }
-               /* if (ImGui::TreeNode("Sequence"))
-                {
-                    ImGui::Text("Sequence For Particle");
-                    ImGui::Checkbox("Enable Sequence", &initParams_.enableSequence);
-                    if(initParams_.enableSequence)
-                        ImGui::Checkbox("Show Sequence", &isOpenTimeline);
-                    ImGui::TreePop();
-                }*/
+                ImGui::TreePop();
             }
 
+            if (parentTransform_ != nullptr)
+            {
+                if (ImGui::TreeNode("Emitter Offset"))
+                {
+                    ImGui::DragFloat3("Offset", &offset_.x, 0.01f);
+                    ImGui::TreePop();
+                }
+            }
         }
-        ImGui::EndTabItem();
+
+        if (ImGui::CollapsingHeader("Particle Init Params"))
+        {
+            if (ImGui::TreeNode("Use Model"))
+            {
+                ImGui::Text("ModelPath");
+                ImGui::InputText("##ModelPath", modelPath_, 256);
+                if (ImGui::Button("Apply##ModelPath"))
+                {
+                    Model* model = Model::CreateFromFile(modelPath_);
+                    useModelName_ = modelPath_;
+                    strcpy_s(modelName_, 256, "");
+                }
+                ImGui::Separator();
+                ImGui::Text("ModelName");
+                ImGui::InputText("##ModelName", modelName_, 256);
+                if (ImGui::Button("Apply##ModelName"))
+                {
+                    Model* model = ModelManager::GetInstance()->FindSameModel(modelName_);
+                    if (model == nullptr)
+                    {
+                        throw std::runtime_error("Model not found");
+                    }
+                    else
+                    {
+                        useModelName_ = modelName_;
+                        strcpy_s(modelPath_, 256, "");
+                    }
+                }
+                ImGui::TreePop();
+            }
+
+            if (ImGui::TreeNode("Use Texture"))
+            {
+                ImGui::Text("TextureRoot");
+                ImGui::InputText("##TextureRoot", textureRoot_, 256);
+
+                ImGui::Text("TexturePath");
+                ImGui::InputText("##TexturePath", texturePath_, 256);
+                if (ImGui::Button("Apply##TexturePath"))
+                {
+                    initParams_.textureName = texturePath_;
+                    TextureManager::GetInstance()->Load(texturePath_, textureRoot_);
+                }
+                ImGui::TreePop();
+            }
+
+            if (ImGui::TreeNode("Billboard"))
+            {
+                ImGui::Text("Billboard");
+                ImGui::Checkbox("X", &initParams_.billboard[0]);            ImGui::SameLine();
+                ImGui::Checkbox("Y", &initParams_.billboard[1]);            ImGui::SameLine();
+                ImGui::Checkbox("Z", &initParams_.billboard[2]);
+                ImGui::TreePop();
+            }
+
+            // RenderSetting
+            if (ImGui::TreeNode("Render Setting"))
+            {
+                ImGui::Text("Blend Mode");
+                ImGui::RadioButton("Normal", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Normal));
+                ImGui::RadioButton("Add", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Add));
+                ImGui::RadioButton("Sub", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Sub));
+                ImGui::RadioButton("Mul", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Multiply));
+                ImGui::RadioButton("Screen", reinterpret_cast<int*>(&blendMode_), static_cast<int>(BlendMode::Screen));
+
+                ImGui::Separator();
+
+                ImGui::Checkbox("Cull Back", &cullBack_);
+
+                ImGui::TreePop();
+            }
+
+            if (ImGui::TreeNode("Life Time"))
+            {
+                DebugWindowForLifeTime();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Position"))
+            {
+                DebugWindowForPosition();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Size"))
+            {
+                DebugWindowForSize();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Direction"))
+            {
+                DebugWindowForDirection();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Speed"))
+            {
+                DebugWindowForSpeed();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Rotation"))
+            {
+                DebugWindowForRotation();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Deceleration"))
+            {
+                DebugWindowForDeceleration();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Color"))
+            {
+                DebugWindowForColor();
+                ImGui::TreePop();
+            }
+            if (ImGui::TreeNode("Modifiers"))
+            {
+                DebugWindowForModifier();
+                ImGui::TreePop();
+            }
+           /* if (ImGui::TreeNode("Sequence"))
+            {
+                ImGui::Text("Sequence For Particle");
+                ImGui::Checkbox("Enable Sequence", &initParams_.enableSequence);
+                if(initParams_.enableSequence)
+                    ImGui::Checkbox("Show Sequence", &isOpenTimeline);
+                ImGui::TreePop();
+            }*/
+        }
+
     }
+    ImGui::PopID(); // Pop ID for this emitter
 
 #endif // _DEBUG
 

--- a/Engine/Features/Effect/Manager/ParticleSystem.cpp
+++ b/Engine/Features/Effect/Manager/ParticleSystem.cpp
@@ -24,6 +24,8 @@ ParticleSystem::~ParticleSystem()
     ClearParticles();
 
     delete factory_;
+    factory_ = nullptr;
+
 }
 
 void ParticleSystem::Initialize()
@@ -71,23 +73,25 @@ void ParticleSystem::Update(float _deltaTime)
                     CreateModifier(name);
                     it = modifierNames_.find(name);
                 }
-
-                it->second->Apply(particles, _deltaTime);
+                std::list<Particle*> raw_particles;
+                for (auto& smart_ptr : particles)
+                {
+                    raw_particles.push_back(smart_ptr.get());
+                }
+                it->second->Apply(raw_particles, _deltaTime);
             }
         }
 
         for (auto it = particles.begin(); it != particles.end();)
         {
-            Particle* particle = *it;
-
-            particle->Update(_deltaTime);
+            auto& particle = *it;
 
             if (!particle->IsAlive())
             {
-                delete particle;
                 it = particles.erase(it);
                 continue;
             }
+            particle->Update(_deltaTime);
 
             Matrix4x4 affineMatrix =
                 MakeScaleMatrix(particle->GetScale()) *
@@ -137,13 +141,19 @@ void ParticleSystem::SetModifierFactory(IParticleMoifierFactory* _factory)
         return;
 
     if (factory_ != nullptr)
+    {
         delete factory_;
+        factory_ = nullptr;
+    }
 
     factory_ = _factory;
 }
 
 void ParticleSystem::AddParticle(const std::string& _groupName, const std::string& _useModelName, Particle* _particle, ParticleRenderSettings _settings, uint32_t _textureHandle, std::vector<std::string> _modifiers)
 {
+    std::unique_ptr<Particle> particle_ptr(_particle);
+
+
     ParticleKey key;
     key.modelName = _useModelName;
     key.settings = _settings;
@@ -151,11 +161,11 @@ void ParticleSystem::AddParticle(const std::string& _groupName, const std::strin
     auto it = particles_.find(_groupName);
     if (it == particles_.end())
     {
-        ParticleGroup group;
+        ParticleGroup& group = particles_[_groupName];
         group.key = key;
         group.srvIndex = srvManager_->Allocate();
         group.instanceCount = 0;
-        group.particles.push_back(_particle);
+        group.particles.push_back(std::move(particle_ptr));
 
         group.instanceBuffer = DXCommon::GetInstance()->CreateBufferResource(sizeof(ParticleForGPU) * maxInstancesPerGroup);
         group.instanceBuffer->Map(0, nullptr, reinterpret_cast<void**>(&group.mappedInstanceBuffer));
@@ -180,12 +190,10 @@ void ParticleSystem::AddParticle(const std::string& _groupName, const std::strin
         {
             group.useModifierName[name] = 1;
         }
-
-        particles_[_groupName] = group;
     }
     else
     {
-        it->second.particles.push_back(_particle);
+        it->second.particles.push_back(std::move(particle_ptr));
     }
 
     // モディファイアの登録
@@ -198,6 +206,7 @@ void ParticleSystem::AddParticle(const std::string& _groupName, const std::strin
 
 void ParticleSystem::AddParticles(const std::string& _groupName, const std::string& _useModelName, std::vector<Particle*> _particles, ParticleRenderSettings _settings, uint32_t _textureHandle, std::vector<std::string> _modifiers)
 {
+
     ParticleKey key;
     key.modelName = _useModelName;
     key.settings = _settings;
@@ -205,12 +214,16 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
     auto it = particles_.find(_groupName);
     if (it == particles_.end())
     {
-        ParticleGroup group;
+        ParticleGroup& group = particles_[_groupName];
         group.key = key;
 
         group.srvIndex = srvManager_->Allocate();
         group.instanceCount = 0;
-        group.particles = std::list<Particle*>(_particles.begin(), _particles.end());
+
+        for (Particle* particle : _particles)
+        {
+            group.particles.push_back(std::unique_ptr<Particle>(particle));
+        }
 
         group.instanceBuffer = DXCommon::GetInstance()->CreateBufferResource(sizeof(ParticleForGPU) * maxInstancesPerGroup);
         group.instanceBuffer->Map(0, nullptr, reinterpret_cast<void**>(&group.mappedInstanceBuffer));
@@ -230,34 +243,25 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
 
         group.psoIndex = psoFlags;
         group.textureHandle = _textureHandle;
-
-        particles_[_groupName] = group;
     }
     else
     {
         auto& group = it->second;
 
-        group.particles.insert(it->second.particles.end(), _particles.begin(), _particles.end());
-        group.key = key;
-        particles_[_groupName].textureHandle = _textureHandle;
-
-
-        group.model = ModelManager::GetInstance()->FindSameModel(_useModelName);
-        if (group.model == nullptr)
-            throw std::runtime_error("Modelname '" + _useModelName + "'  が無効です。");
-
-        PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
-
-        // PSOFlagsが未登録の場合は登録する
-        if (!psoMap_.contains(psoFlags))
-            psoMap_[psoFlags] = PSOManager::GetInstance()->GetPipeLineStateObject(psoFlags).value();
-
-        group.psoIndex = psoFlags;
+        // パーティクルだけを追加
+        for (Particle* particle : _particles)
+        {
+            group.particles.push_back(std::unique_ptr<Particle>(particle));
+        }
         group.textureHandle = _textureHandle;
 
-        particles_[_groupName] = group;
-
+        // モデルが異なる場合のみ更新
+        if (group.model == nullptr || group.key.modelName != _useModelName)
+        {
+            group.model = ModelManager::GetInstance()->FindSameModel(_useModelName);
+            if (group.model == nullptr)
+                throw std::runtime_error("Modelname '" + _useModelName + "'  が無効です。");
+        }
     }
 
     // モディファイアの登録
@@ -270,29 +274,14 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
 
 void ParticleSystem::ClearParticles()
 {
-    for (auto& [key, particleList] : particles_)
-    {
-        for (auto& particle : particleList.particles)
-        {
-            delete particle;
-        }
-        particleList.particles.clear();
-    }
     particles_.clear();
 }
 
 void ParticleSystem::ClearParticles(const std::string& _groupName)
 {
     auto it = particles_.find(_groupName);
-    if (it == particles_.end())
-        return;
-
-    ParticleGroup& particleList = it->second;
-    for (auto& particle : particleList.particles)
-    {
-        delete particle;
-    }
-    particleList.particles.clear();
+    if (it != particles_.end())
+        it->second.particles.clear();
 }
 
 void ParticleSystem::CreateModifier(const std::string& _name)

--- a/Engine/Features/Effect/Manager/ParticleSystem.h
+++ b/Engine/Features/Effect/Manager/ParticleSystem.h
@@ -120,7 +120,7 @@ private:
     {
         ParticleKey key;
         Model* model = nullptr;
-        std::list<Particle*> particles;
+        std::list <std::unique_ptr<Particle>> particles;
         uint32_t srvIndex = 0;
         uint32_t instanceCount = 0;
         PSOFlags psoIndex = {};


### PR DESCRIPTION
ParticleEmitter::ShowDebugWindow では、デバッグウィンドウの表示コードを整理し、可読性を向上させました。

ParticleSystem クラスのデストラクタで factory_ ポインタを nullptr に設定し、メモリリークを防ぐ安全性を向上させました。

Update メソッドでは、パーティクルのリストをスマートポインタから生ポインタに変換し、メモリ管理を改善しました。

SetModifierFactory メソッドにおいて、ファクトリーポインタが nullptr の場合の処理を追加し、エラーハンドリングを強化しました。

AddParticle および AddParticles メソッドでは、パーティクルを std::unique_ptr で管理するように変更し、手動でのメモリ解放を不要にしました。

ClearParticles メソッドでは、パーティクルの削除処理を簡素化し、メモリ管理を改善しました。

ParticleGroup 構造体では、std::list<Particle*> を std::list<std::unique_ptr<Particle>> に変更し、メモリ管理を自動化しました。