### PR TITLE
影描画時に引数で渡していたIDResourceは不要になったの排除

### DIFF
--- a/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
@@ -1349,7 +1349,7 @@ void PSOManager::CreatePSOForDLShadowMap()
     descriptionRootSignature.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
 
     //RootParameter作成
-    D3D12_ROOT_PARAMETER rootParameters[4] = {};
+    D3D12_ROOT_PARAMETER rootParameters[3] = {};
 
     //カメラ
     rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
@@ -1361,14 +1361,10 @@ void PSOManager::CreatePSOForDLShadowMap()
     rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
     rootParameters[1].Descriptor.ShaderRegister = 1;
 
-    // id
-    rootParameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
-    rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-    rootParameters[2].Descriptor.ShaderRegister = 2;
     // LightGroup
-    rootParameters[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
-    rootParameters[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
-    rootParameters[3].Descriptor.ShaderRegister = 3;
+    rootParameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+    rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[2].Descriptor.ShaderRegister = 3;
 
 
 
@@ -1499,7 +1495,7 @@ void PSOManager::CreatePSOForPLShadowMap()
     descriptionRootSignature.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
 
     //RootParameter作成
-    D3D12_ROOT_PARAMETER rootParameters[3] = {};
+    D3D12_ROOT_PARAMETER rootParameters[2] = {};
 
 
     // transform
@@ -1512,10 +1508,6 @@ void PSOManager::CreatePSOForPLShadowMap()
     rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_GEOMETRY;
     rootParameters[1].Descriptor.ShaderRegister = 1;
 
-    // id
-    rootParameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
-    rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-    rootParameters[2].Descriptor.ShaderRegister = 2;
 
     descriptionRootSignature.pStaticSamplers = nullptr;
     descriptionRootSignature.NumStaticSamplers = 0;

--- a/Engine/Features/Model/Model.cpp
+++ b/Engine/Features/Model/Model.cpp
@@ -160,17 +160,9 @@ void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList) const
 {
     QueueLightCommand(_commandList, 5);
 
-    bool hasAnimation = HasAnimation() && currentAnimation_ && currentAnimation_->IsPlaying();
-
     for (auto& mesh : mesh_)
     {
-        //if (!hasAnimation)
-            mesh->QueueCommand(_commandList);
-        /*else
-        {
-            mesh->QueueCommand(_commandList, skinCluster_.GetInfluenceBufferView());
-            skinCluster_.QueueCommand(_commandList);
-        }*/
+        mesh->QueueCommand(_commandList);
         material_[mesh->GetUseMaterialIndex()]->TransferData();
         material_[mesh->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
         material_[mesh->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4);
@@ -182,17 +174,10 @@ void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_
 {
     QueueLightCommand(_commandList, 5);
 
-    bool hasAnimation = HasAnimation() && currentAnimation_ && currentAnimation_->IsPlaying();
 
     for (auto& mesh : mesh_)
     {
-        //if (!hasAnimation)
-            mesh->QueueCommand(_commandList);
-        /*else
-        {
-            mesh->QueueCommand(_commandList, skinCluster_.GetInfluenceBufferView());
-            skinCluster_.QueueCommand(_commandList);
-        }*/
+        mesh->QueueCommand(_commandList);
         material_[mesh->GetUseMaterialIndex()]->TransferData();
         material_[mesh->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
         material_[mesh->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4, _textureHandle);
@@ -202,7 +187,7 @@ void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_
 
 void Model::QueueCommandForShadow(ID3D12GraphicsCommandList* _commandList) const
 {
-    QueueLightCommand(_commandList, 3);
+    QueueLightCommand(_commandList, 2);
     for (auto& mesh : mesh_)
     {
         mesh->QueueCommand(_commandList);

--- a/Engine/Features/Model/ObjectModel.h
+++ b/Engine/Features/Model/ObjectModel.h
@@ -13,12 +13,16 @@ public:
     ~ObjectModel();
 
     void Initialize(const std::string& _filePath);
-    void Initialize(std::unique_ptr< Mesh> _mesh);
+    void Initialize(std::unique_ptr<Mesh> _mesh);
     void Initialize(Model* _model);
+
     void Update();
+
     void Draw(const Camera* _camera ,const Vector4& _color);
     void Draw(const Camera* _camera, uint32_t _textureHandle, const Vector4& _color);
-    void DrawShadow(const Camera* _camera,  uint32_t _id);
+    void DrawShadow(const Camera* _camera);
+
+
     void UseQuaternion(bool _use) { useQuaternion_ = _use; }
 
     void LoadAnimation(const std::string& _filePath, const std::string& _name);
@@ -66,11 +70,6 @@ private:
     std::string timeChannel = "default";
     GameTime* gameTime_ = nullptr;
 
-    uint32_t* idForGPU = nullptr;
-    Microsoft::WRL::ComPtr<ID3D12Resource> idResource_ = nullptr;
-
     char filePathBuffer_[128];
-
-    void CreateIDResource();
 
 };

--- a/Sample/Resources/Shader/PointLightShadowMap.hlsl
+++ b/Sample/Resources/Shader/PointLightShadowMap.hlsl
@@ -53,11 +53,6 @@ cbuffer gLightGroup : register(b1)
     PointLight PL;
 };
 
-cbuffer id : register(b2)
-{
-    uint id;
-}
-
 VSOutput VSmain(VSInput _input)
 {
     VSOutput output;
@@ -99,12 +94,8 @@ PSOutput PSmain(GSOutput input)
 {
     PSOutput output;
 
-    float r = (id & 0xFF) / 255.0; // 下位8bit
-    float g = ((id >> 8) & 0xFF) / 255.0; // 中位8bit
-    float b = ((id >> 16) & 0xFF) / 255.0; // 上位8bit
-
-    float a = 1.0f;
-    output.data = float4(r, g, b, a);
+    float z = input.Position.z / input.Position.w; // NDC座標のZ値を取得
+    output.data = float4(z, z, z, 1.0f);
 
     return output;
 }

--- a/Sample/Resources/Shader/ShadowMap.hlsl
+++ b/Sample/Resources/Shader/ShadowMap.hlsl
@@ -19,11 +19,6 @@ struct PixelShaderOutput
     float4 data : SV_TARGET0;
 };
 
-cbuffer gID : register(b2)
-{
-    uint id;
-}
-
 VertexShaderOutput ShadowMapVS(VertexShaderInput _input)
 {
 
@@ -44,12 +39,8 @@ PixelShaderOutput ShadowMapPS(VertexShaderOutput _input)
 {
     PixelShaderOutput output;
 
-    float r = (id & 0xFF) / 255.0; // 下位8bit
-    float g = ((id >> 8) & 0xFF) / 255.0; // 中位8bit
-    float b = ((id >> 16) & 0xFF) / 255.0; // 上位8bit
+    float z = _input.shadowPos.z / _input.shadowPos.w; // NDC座標のZ値を取得
 
-    float a = 1.0f;
-    output.data = float4(r, g, b, a);
-
+    output.data = float4(z, z, z, 1.0f);
     return output;
 }

--- a/Sample/SampleScene.cpp
+++ b/Sample/SampleScene.cpp
@@ -213,7 +213,7 @@ void SampleScene::Draw()
 
 void SampleScene::DrawShadow()
 {
-    human_->DrawShadow(&SceneCamera_,0);
+    human_->DrawShadow(&SceneCamera_);
 }
 
 #ifdef _DEBUG


### PR DESCRIPTION
ルートパラメータの変更と関数の引数削除

PSOManager.cppの`CreatePSOForDLShadowMap`および`CreatePSOForPLShadowMap`関数でルートパラメータの数を減少させ、設定を変更しました。Model.cppの`QueueCommandAndDraw`関数ではアニメーションチェックを削除し、すべてのメッシュに対して`QueueCommand`を呼び出すようにしました。ObjectModel.cppおよびObjectModel.hでは、`DrawShadow`関数の引数を削除し、`CreateIDResource`関数を削除しました。シェーダーファイルでは、`id`に関するcbufferを削除し、色の計算をZ値に基づくものに変更しました。SampleScene.cppでは、`DrawShadow`メソッドの呼び出しから`0`引数を削除しました。