### PR TITLE
衝突判定をシングルスレッドで動作するよう修正

### DIFF
--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -266,9 +266,9 @@ DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
     DockNode    ID=0x00000004 Parent=0x00000005 SizeRef=1280,255 Selected=0x4F89F0DC
   DockNode      ID=0x00000006 Parent=0x08BD597D SizeRef=348,720 Split=Y Selected=0x4B6712B0
     DockNode    ID=0x0000000B Parent=0x00000006 SizeRef=88,377 Split=X Selected=0x1E7E18E3
-      DockNode  ID=0x00000007 Parent=0x0000000B SizeRef=61,210 Selected=0x1E7E18E3
-      DockNode  ID=0x00000008 Parent=0x0000000B SizeRef=285,210 Selected=0x4B6712B0
+      DockNode  ID=0x00000007 Parent=0x0000000B SizeRef=129,210 Selected=0x1E7E18E3
+      DockNode  ID=0x00000008 Parent=0x0000000B SizeRef=217,210 Selected=0x4B6712B0
     DockNode    ID=0x0000000C Parent=0x00000006 SizeRef=88,341 Split=Y Selected=0xAC437A35
       DockNode  ID=0x00000009 Parent=0x0000000C SizeRef=348,178 Selected=0x9ECF0FAD
-      DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=348,161 Selected=0xDA40672E
+      DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=348,161 Selected=0xB5453E4F
 


### PR DESCRIPTION
CollisionManagerのコード整理と改善

CollisionManager.cppおよびCollisionManager.hにおいて、スレッドセーフな衝突判定管理のためのコードを整理し、冗長な部分を削除しました。衝突判定の実行やコライダーの登録・登録解除の処理が簡素化され、マルチスレッド処理の実装が改善されました。デバッグ描画のフラグをatomicから通常のboolに変更し、スレッドセーフ性を向上させました。また、CollisionCallInfo構造体の定義を削除し、衝突情報の処理を直接的に行うようにしました。これにより、コードの可読性と保守性が向上しています。