### PR TITLE
PSO管理の改善と型の整合性向上

### DIFF
--- a/Engine/Features/Effect/Manager/ParticleSystem.cpp
+++ b/Engine/Features/Effect/Manager/ParticleSystem.cpp
@@ -31,7 +31,7 @@ void ParticleSystem::Initialize()
 {
     srvManager_ = SRVManager::GetInstance();
 
-    auto rootsig = PSOManager::GetInstance()->GetRootSignature(PSOFlags::Type_Particle);
+    auto rootsig = PSOManager::GetInstance()->GetRootSignature(PSOFlags::Type::Particle);
     assert(rootsig.has_value());
     rootSignature_ = rootsig.value();
 }
@@ -178,7 +178,7 @@ void ParticleSystem::AddParticle(const std::string& _groupName, const std::strin
         group.model = ModelManager::GetInstance()->FindSameModel(_useModelName);
 
         PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
+        psoFlags = psoFlags | PSOFlags::Type::Particle | PSOFlags::DepthMode::Comb_mZero_fLessEqual;
 
         // PSOFlagsが未登録の場合は登録する
         if (!psoMap_.contains(psoFlags))
@@ -197,7 +197,7 @@ void ParticleSystem::AddParticle(const std::string& _groupName, const std::strin
     else
     {
         PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
+        psoFlags = psoFlags | PSOFlags::Type::Particle | PSOFlags::DepthMode::Comb_mZero_fLessEqual;
 
         // PSOFlagsが未登録の場合は登録する
         if (!psoMap_.contains(psoFlags))
@@ -247,7 +247,7 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
             throw std::runtime_error("Modelname '" + _useModelName + "'  が無効です。");
 
         PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
+        psoFlags = psoFlags | PSOFlags::Type::Particle | PSOFlags::DepthMode::Comb_mZero_fLessEqual;
 
         // PSOFlagsが未登録の場合は登録する
         if (!psoMap_.contains(psoFlags))
@@ -268,7 +268,7 @@ void ParticleSystem::AddParticles(const std::string& _groupName, const std::stri
         group.textureHandle = _textureHandle;
 
         PSOFlags psoFlags = _settings.GetPSOFlags();
-        psoFlags |= PSOFlags::Type_Particle | PSOFlags::Depth_mZero_fLEqual;
+        psoFlags = psoFlags | PSOFlags::Type::Particle | PSOFlags::DepthMode::Comb_mZero_fLessEqual;
 
         // PSOFlagsが未登録の場合は登録する
         if (!psoMap_.contains(psoFlags))

--- a/Engine/Features/Effect/Manager/ParticleSystem.h
+++ b/Engine/Features/Effect/Manager/ParticleSystem.h
@@ -23,33 +23,33 @@ struct ParticleRenderSettings
 
     PSOFlags GetPSOFlags() const
     {
-        PSOFlags flags = PSOFlags::None;
+        PSOFlags flags = PSOFlags::BlendMode::Normal;
 
         switch (blendMode)
         {
         case BlendMode::Normal:
-            flags |= PSOFlags::Blend_Normal;
+            flags = flags | PSOFlags::BlendMode::Normal;
             break;
         case BlendMode::Add:
-            flags |= PSOFlags::Blend_Add;
+            flags = flags | PSOFlags::BlendMode::Add;
             break;
         case BlendMode::Sub:
-            flags |= PSOFlags::Blend_Sub;
+            flags = flags | PSOFlags::BlendMode::Sub;
             break;
         case BlendMode::Multiply:
-            flags |= PSOFlags::Blend_Multiply;
+            flags = flags | PSOFlags::BlendMode::Multiply;
             break;
         case BlendMode::Screen:
-            flags |= PSOFlags::Blend_Screen;
+            flags = flags | PSOFlags::BlendMode::Screen;
             break;
         default:
             break;
         }
 
         if (cullBack)
-            flags |= PSOFlags::Cull_Back;
+            flags = flags | PSOFlags::CullMode::Back;
         else
-            flags |= PSOFlags::Cull_None;
+            flags = flags | PSOFlags::CullMode::None;
 
 
         return flags;

--- a/Engine/Features/Json/Loader/JsonLoader.cpp
+++ b/Engine/Features/Json/Loader/JsonLoader.cpp
@@ -21,6 +21,26 @@ JsonLoader::JsonLoader(const std::string& _directory, bool _autoSave) {
 JsonLoader::~JsonLoader() {
 }
 
+json JsonLoader::LoadFile(const std::string& _filepath)
+{
+    std::ifstream inputFile(_filepath);
+    if (!inputFile.is_open())
+    {
+        assert(inputFile.is_open() && "Cant Open inputFile");
+        return json();
+    }
+
+    json j;
+    if (inputFile.peek() != std::ifstream::traits_type::eof())
+    {
+        inputFile >> j;
+    }
+
+    inputFile.close();
+    return j;
+
+}
+
 void JsonLoader::LoadJson(const std::string& _filepath, bool _isMakeFile) {
 
     // 拡張子の有無

--- a/Engine/Features/Json/Loader/JsonLoader.h
+++ b/Engine/Features/Json/Loader/JsonLoader.h
@@ -22,6 +22,12 @@ public:
     JsonLoader(const std::string& _directory, bool _autoSave = true);
     ~JsonLoader();
 
+    /// <summary>
+    /// Jsonファイルを読み込む
+    /// </summary>
+    static json LoadFile(const std::string& _filepath);
+
+
     void LoadJson(const std::string& _filepath, bool _isMakeFile = false);
     void MakeJsonFile()const;
 

--- a/Engine/Features/LineDrawer/LineDrawer.cpp
+++ b/Engine/Features/LineDrawer/LineDrawer.cpp
@@ -13,8 +13,7 @@ LineDrawer* LineDrawer::GetInstance()
 
 void LineDrawer::Initialize()
 {
-    psoFlags_ = PSOFlags::Type_LineDrawer | PSOFlags::Blend_Normal | PSOFlags::Cull_None |
-        PSOFlags::Depth_mZero_fLEqual;
+    psoFlags_ = PSOFlags::ForLineDrawer();
 
     index = 0u;
     color_ = { 0.0f,0.0f,0.0f,1.0f };

--- a/Engine/Features/Model/Manager/ModelManager.cpp
+++ b/Engine/Features/Model/Manager/ModelManager.cpp
@@ -12,8 +12,8 @@ ModelManager* ModelManager::GetInstance()
 
 void ModelManager::Initialize()
 {
-    psoFlags_ = PSOFlags::Type_Model | PSOFlags::Blend_Normal | PSOFlags::Cull_Back | PSOFlags::Depth_mAll_fLEqual;
-    psoFlagsForAlpha_ = PSOFlags::Type_Model | PSOFlags::Blend_Normal | PSOFlags::Cull_Back | PSOFlags::Depth_mZero_fLEqual;
+    psoFlags_ = PSOFlags::ForNormalModel();
+    psoFlagsForAlpha_ = PSOFlags::ForAlphaModel();
 
 
     /// PSOを取得

--- a/Engine/Features/Model/ObjectModel.cpp
+++ b/Engine/Features/Model/ObjectModel.cpp
@@ -139,8 +139,8 @@ void ObjectModel::DrawShadow(const Camera* _camera)
     {
         RTVManager::GetInstance()->SetRenderTexture("ShadowMap");
 
-        PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type_DLShadowMap);
-        PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type_DLShadowMap);
+        PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type::DLShadowMap);
+        PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type::DLShadowMap);
 
         _camera->QueueCommand(commandList, 0);
         worldTransform_.QueueCommand(commandList, 1);
@@ -155,8 +155,8 @@ void ObjectModel::DrawShadow(const Camera* _camera)
         if (!pointLight->IsCastShadow())
             continue;
 
-        PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type_PLShadowMap);
-        PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type_PLShadowMap);
+        PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type::PLShadowMap);
+        PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type::PLShadowMap);
 
         auto handles = pointLight->GetShadowMapHandles();
         uint32_t handle = handles[0];

--- a/Engine/Features/Model/SkyBox.cpp
+++ b/Engine/Features/Model/SkyBox.cpp
@@ -12,9 +12,24 @@ void SkyBox::Initialize(const Vector3& _scale, bool _useQuaternion)
     PSOManager* psoManager = PSOManager::GetInstance();
     psoManager->CreatePSOForSkyBox();
 
-    pipelineState_ = psoManager->GetPipeLineStateObject(PSOFlags::Type_SkyBox | PSOFlags::Blend_Normal | PSOFlags::Cull_Back).value();
 
-    rootSignature_ = psoManager->GetRootSignature(PSOFlags::Type_SkyBox).value();
+    auto pso = psoManager->GetPipeLineStateObject(PSOFlags::Combine(PSOFlags::Type::SkyBox , PSOFlags::BlendMode::Normal , PSOFlags::CullMode::Back,PSOFlags::DepthMode::Comb_mAll_fLessEqual));
+    if (!pso.has_value() || pso.value() == nullptr)
+    {
+        assert(0 && "PSO for SkyBox is not created");
+        return;
+    }
+    pipelineState_ = pso.value();
+
+    // RootSignature
+    auto rs = psoManager->GetRootSignature(PSOFlags::Type::SkyBox);
+    if (!rs.has_value() || rs.value() == nullptr)
+    {
+        assert(0 && "RootSignature for SkyBox is not created");
+        return;
+    }
+    rootSignature_ = rs.value();
+
 
     // 初期化
     worldTransform_.Initialize();

--- a/Engine/Features/Sprite/SpriteManager.cpp
+++ b/Engine/Features/Sprite/SpriteManager.cpp
@@ -10,15 +10,16 @@ SpriteManager* SpriteManager::GetInstance()
 
 void SpriteManager::Initialize()
 {
+    PSOFlags flag = PSOFlags::ForSprite();
 
     /// PSOを取得
-    auto pso = PSOManager::GetInstance()->GetPipeLineStateObject(PSOFlags::Type_Sprite | PSOFlags::Blend_Normal | PSOFlags::Cull_Back);
+    auto pso = PSOManager::GetInstance()->GetPipeLineStateObject(flag);
     // PSOが生成されているか確認
     assert(pso.has_value() && pso != nullptr);
     graphicsPipelineState_ = pso.value();
 
     /// RootSingnatureを取得
-    auto rootSignature = PSOManager::GetInstance()->GetRootSignature(PSOFlags::Type_Sprite | PSOFlags::Blend_Normal | PSOFlags::Cull_Back);
+    auto rootSignature = PSOManager::GetInstance()->GetRootSignature(flag);
     // 生成されているか確認
     assert(rootSignature.has_value() && rootSignature != nullptr);
     rootSignature_ = rootSignature.value();

--- a/Sample/SampleFramework.cpp
+++ b/Sample/SampleFramework.cpp
@@ -129,8 +129,8 @@ void SampleFramework::Draw()
     // スワップチェインに戻す
     rtvManager_->SetSwapChainRenderTexture(dxCommon_->GetSwapChain());
 
-    PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type_OffScreen);
-    PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type_OffScreen);
+    PSOManager::GetInstance()->SetRootSignature(PSOFlags::Type::OffScreen);
+    PSOManager::GetInstance()->SetPipeLineStateObject(PSOFlags::Type::OffScreen);
 
     // レンダーテクスチャを描画
     rtvManager_->DrawRenderTexture(currentTex_);

--- a/Sample/SampleScene.cpp
+++ b/Sample/SampleScene.cpp
@@ -30,7 +30,7 @@ void SampleScene::Initialize(SceneData* _sceneData)
 
 
     lineDrawer_ = LineDrawer::GetInstance();
-    lineDrawer_->Initialize();
+    //lineDrawer_->Initialize();
     lineDrawer_->SetCameraPtr(&SceneCamera_);
 
     input_ = Input::GetInstance();

--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -269,6 +269,6 @@ DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
       DockNode  ID=0x00000007 Parent=0x0000000B SizeRef=129,210 Selected=0x1E7E18E3
       DockNode  ID=0x00000008 Parent=0x0000000B SizeRef=217,210 Selected=0x4B6712B0
     DockNode    ID=0x0000000C Parent=0x00000006 SizeRef=88,341 Split=Y Selected=0xAC437A35
-      DockNode  ID=0x00000009 Parent=0x0000000C SizeRef=348,178 Selected=0x9ECF0FAD
+      DockNode  ID=0x00000009 Parent=0x0000000C SizeRef=348,178 Selected=0xAC437A35
       DockNode  ID=0x0000000D Parent=0x0000000C SizeRef=348,161 Selected=0xB5453E4F
 


### PR DESCRIPTION
`PSOManager` クラスの `Initialize()` メソッドで、複数のPSOを作成する代わりに `CreateDefaultPSOs()` を呼び出すように変更し、コードの可読性を向上させました。 `GetPipeLineStateObject()`, `SetPipeLineStateObject()`, `SetRootSignature()` メソッドで、インデックスの型を `size_t` から `uint64_t` に変更し、型の整合性を強化しました。 PSOFlagsの生成方法を複数のメソッドで改善し、より明確にしました。
新たに `LoadFile()` メソッドを `JsonLoader` クラスに追加し、JSONファイルの読み込み機能を実装しました。 `PSOFlags` 構造体を新たに定義し、フラグの管理を改善しました。
その他、関連するクラス内でのPSOFlagsの生成方法の変更や、ドックスペース設定の更新も行いました。