### PR TITLE
モデルパスの設定を改善

### DIFF
--- a/Engine/LevelEditorLoader.cpp
+++ b/Engine/LevelEditorLoader.cpp
@@ -65,7 +65,15 @@ void LevelEditorLoader::Load(const std::string& _filePath)
                 }
                 param.colliders.push_back(colliderParam);
             }
+        }
 
+        if (obj.contains("file_name"))
+        {
+            param.modelPath = obj["file_name"].get<std::string>(); // ファイル名を設定
+        }
+        else
+        {
+            param.modelPath = "cube/cube.obj"; // デフォルトのファイル名を設定
         }
 
         if (obj.contains("children"))

--- a/Sample/deveScene/DeveScene.cpp
+++ b/Sample/deveScene/DeveScene.cpp
@@ -115,7 +115,7 @@ void DeveScene::Initialize(SceneData* _sceneData)
     {
         auto model = std::make_unique<ObjectModel>(params.name);
         // モデルのを読み込む
-        model->Initialize("suzune.obj");
+        model->Initialize(params.modelPath);
 
         model->translate_ = params.position;
         model->euler_ = params.rotation;
@@ -127,7 +127,7 @@ void DeveScene::Initialize(SceneData* _sceneData)
             for (const auto& child : params.childParameters)
             {
                 auto childModel = std::make_unique<ObjectModel>(child.name);
-                childModel->Initialize("cube/cube.obj");
+                childModel->Initialize(child.modelPath);
                 childModel->translate_ = child.position;
                 childModel->euler_ = child.rotation;
                 childModel->scale_ = child.scale;
@@ -140,9 +140,7 @@ void DeveScene::Initialize(SceneData* _sceneData)
         }
 
         models_.push_back(std::move(model));
-
     }
-
 
 }
 


### PR DESCRIPTION
`LevelEditorLoader::Load` メソッドで、`file_name` が存在する場合に `param.modelPath` に設定する処理を追加しました。デフォルトのファイル名は `"cube/cube.obj"` です。

`DeveScene::Initialize` メソッド内で、オブジェクトモデルと子オブジェクトモデルの初期化時にハードコーディングされたファイル名を削除し、それぞれ `params.modelPath` と `child.modelPath` を使用するように変更しました。

不要な行を削除しました。