### PR TITLE
カメラ機能の拡張と投影行列の改善

### DIFF
--- a/Engine/Features/Camera/Camera/Camera.cpp
+++ b/Engine/Features/Camera/Camera/Camera.cpp
@@ -9,10 +9,22 @@
 #endif // _DEBUG
 
 
-void Camera::Initialize()
+void Camera::Initialize(CameraType _cameraType, const Vector2& _winSize)
 {
+
+    cameraType_ = _cameraType;
+    winSize_ = _winSize;
+    aspectRatio_ = winSize_.x / winSize_.y;
+
+    if (cameraType_ == CameraType::Orthographic)
+    {
+        LeftTop_ = { winSize_.x * -0.5f, winSize_.y * 0.5f};
+        RightBottom_ = { winSize_.x * 0.5f, winSize_.y * -0.5f };
+    }
+
     Map();
     UpdateMatrix();
+
 
     gameTime_ = GameTime::GetInstance();
 }
@@ -77,7 +89,17 @@ void Camera::UpdateMatrix()
     matView_ = Inverse(matWorld_);
     //translate_ = { 0,500,0 };
     //matView_ = LoolAt(translate_, { 0,0,0 }, { 1,0,0 });
-    matProjection_ = MakePerspectiveFovMatrix(fovY_, aspectRatio_, nearClip_, farClip_);
+    switch (cameraType_)
+    {
+    case CameraType::Perspective:
+        matProjection_ = MakePerspectiveFovMatrix(fovY_, aspectRatio_, nearClip_, farClip_);
+        break;
+    case CameraType::Orthographic:
+        matProjection_ = MakeOrthographicMatrix(LeftTop_.x, LeftTop_.y, RightBottom_.x, RightBottom_.y, nearClip_, farClip_);
+        break;
+    default:
+        break;
+    }
     //matProjection_ = MakeOrthographicMatrix(0, 0, 1280, 720, 0.1f, 1000.0f);
     matViewProjection_ = matView_ * matProjection_;
 

--- a/Engine/Features/Camera/Camera/Camera.h
+++ b/Engine/Features/Camera/Camera/Camera.h
@@ -7,6 +7,12 @@
 #include <wrl.h>
 #include <d3d12.h>
 
+enum class CameraType
+{
+    Perspective,
+    Orthographic
+};
+
 class Camera
 {
 public:
@@ -14,7 +20,7 @@ public:
     Camera() = default;
     ~Camera() = default;
 
-    void Initialize();
+    void Initialize(CameraType _cameraType = CameraType::Perspective, const Vector2& _winSize = { 1280.0f, 720.0f });
     void Update(bool _showImGui = true);
     void Draw();
 
@@ -61,7 +67,15 @@ public:
 
     Matrix4x4 matView_ = {};
     Matrix4x4 matProjection_ = {};
+
+    // 透視投影か正射影投影か
+    CameraType cameraType_ = CameraType::Perspective;
+
 private:
+    // ortho用
+    Vector2 LeftTop_ = { 0.0f, 0.0f }; // 左上座標
+    Vector2 RightBottom_ = { 1280.0f, 720.0f }; // 右下座標
+    Vector2 winSize_ = { 1280.0f, 720.0f }; // 正射影投影のサイズ
 
     // シェイク用変数たち
     bool shaking_ = false;


### PR DESCRIPTION
`Camera` クラスの `Initialize` メソッドを変更し、カメラのタイプとウィンドウサイズを引数として受け取るようにしました。デフォルトでは、カメラタイプは `Perspective`、ウィンドウサイズは `{ 1280.0f, 720.0f }` です。

`UpdateMatrix` メソッドでは、カメラのタイプに応じて透視投影行列または正射影行列を生成するようにしました。また、`CameraType` 列挙型を追加し、カメラのタイプを `Perspective` と `Orthographic` に分類しました。

さらに、`Camera` クラスのプライベートメンバーにウィンドウサイズや正射影投影のための座標を保持する変数を追加しました。