### PR TITLE
2Dカメラポインタ設定メソッドを追加

### DIFF
--- a/Engine/Features/LineDrawer/LineDrawer.h
+++ b/Engine/Features/LineDrawer/LineDrawer.h
@@ -19,6 +19,7 @@ public:
 
     void Initialize();
     void SetCameraPtr(const Camera* _cameraPtr) { cameraFor3dptr_ = _cameraPtr; }
+    void SetCameraPtr2D(const Camera* _cameraPtr) { cameraFor2dptr_ = _cameraPtr; }
     void SetColor(const Vector4& _color) { color_ = _color; }
     void RegisterPoint(const Vector3& _start, const Vector3& _end);
     void RegisterPoint(const Vector3& _start, const Vector3& _end,const Vector4& _color);


### PR DESCRIPTION
`LineDrawer.h` に `SetCameraPtr2D` メソッドを追加しました。このメソッドは、2Dカメラのポインタを設定するために使用されます。