### PR TITLE
InputText関数をテンプレートに置き換え

### DIFF
--- a/Engine/Debug/ImGuiHelper.cpp
+++ b/Engine/Debug/ImGuiHelper.cpp
@@ -7,28 +7,6 @@
 #include <algorithm>
 #include <numbers>
 
-
-bool ImGuiHelper::InputText(const char* _label, std::string* _str, ImGuiInputTextFlags _flags)
-{
-    // バッファサイズを確保（最低256文字、現在の文字列長+128文字のうち大きい方）
-    size_t buffer_size = (std::max)(_str->capacity() + 1, (std::max)(size_t(256), _str->size() + 128));
-    _str->resize(buffer_size - 1);
-
-    bool result = ImGui::InputText(_label, _str->data(), buffer_size, _flags);
-
-    if (result) {
-        // null terminatorまでの長さに調整
-        _str->resize(strlen(_str->data()));
-    }
-    else {
-        // 変更されていない場合も元のサイズに戻す
-        _str->resize(strlen(_str->data()));
-    }
-
-    return result;
-
-}
-
 void ImGuiHelper::DrawRightPentagon(const ImVec2& _center, const ImVec2& _inscribedRect, float _angle, ImU32 _color)
 {
 

--- a/Engine/Debug/ImGuiHelper.h
+++ b/Engine/Debug/ImGuiHelper.h
@@ -9,8 +9,24 @@
 class AnimationSequence;
 namespace ImGuiHelper
 {
+    template<size_t kBufferSize = 256>
+    bool InputText(const char* _label, std::string& _str, ImGuiInputTextFlags _flags = 0)
+    {
+        bool changed = false;
 
-    bool InputText(const char* _label, std::string* _str, ImGuiInputTextFlags _flags = 0);
+        static char buffer[kBufferSize];
+
+        size_t copySize = (std::min)(_str.length(), kBufferSize - 1); // 末尾のヌル文字を考慮して-1
+        std::memcpy(buffer,_str.c_str(),copySize);
+        buffer[copySize] = '\0'; // ヌル終端
+
+        changed = ImGui::InputText(_label, buffer, kBufferSize, _flags);
+
+        if (changed)
+            _str = std::string(buffer);
+
+        return changed;
+    }
 
     /// <summary>
     /// 直角五角形を描画する


### PR DESCRIPTION
`ImGuiHelper.cpp` から `InputText` 関数を削除し、`ImGuiHelper.h` に固定サイズのバッファを使用する新しいテンプレート関数を追加しました。この変更により、文字列の管理が簡素化され、メモリ管理が改善されました。