### PR TITLE
voiceInstanceから再生してからの時間を取得できるようにゲッターを作成

### DIFF
--- a/Engine/Core/DXCommon/DXCommon.cpp
+++ b/Engine/Core/DXCommon/DXCommon.cpp
@@ -574,8 +574,8 @@ void DXCommon::InitializeFixFPS()
 
 void DXCommon::UpdateFixFPS()
 {
-	const std::chrono::microseconds kMinTime(static_cast<uint64_t>(1000000.0f / 65.0f));
-	const std::chrono::microseconds kMinCheckTime(static_cast<uint64_t>(1000000.0f / 66.0f));
+	const std::chrono::microseconds kMinTime(static_cast<uint64_t>(1000000.0f / 60.0f));
+	const std::chrono::microseconds kMinCheckTime(static_cast<uint64_t>(1000000.0f / 65.0f));
 
 	// 現在時間を取得
 	std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -528,8 +528,6 @@
     <ClCompile Include="System\Audio\AudioSystem.cpp">
       <Filter>System\Audio</Filter>
     </ClCompile>
-    <ClCompile Include="System\Audio\SoundInstance.cpp" />
-    <ClCompile Include="System\Audio\VoiceInstance.cpp" />
     <ClCompile Include="Features\Model\SkyBox.cpp">
       <Filter>Features\Model</Filter>
     </ClCompile>
@@ -557,6 +555,12 @@
     </ClCompile>
     <ClCompile Include="Utility\StringUtils\StringUitls.cpp">
       <Filter>Utility\StringUtils</Filter>
+    </ClCompile>
+    <ClCompile Include="System\Audio\VoiceInstance.cpp">
+      <Filter>System\Audio</Filter>
+    </ClCompile>
+    <ClCompile Include="System\Audio\SoundInstance.cpp">
+      <Filter>System\Audio</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Engine/System/Audio/AudioSystem.cpp
+++ b/Engine/System/Audio/AudioSystem.cpp
@@ -139,8 +139,8 @@ std::shared_ptr<SoundInstance> AudioSystem::Load(const std::string& _filename)
 
     Debug::Log("\tID : " + std::to_string(soundId) + "\n");
 
-    auto soundindtance = std::make_shared<SoundInstance>(soundId,this);
-    soundInstances_[soundId] = soundindtance;
+    auto soundindtance = std::make_shared<SoundInstance>(soundId, this, soundData.wfex.nSamplesPerSec);
+        soundInstances_[soundId] = soundindtance;
 
     return soundindtance;
 }

--- a/Engine/System/Audio/SoundInstance.cpp
+++ b/Engine/System/Audio/SoundInstance.cpp
@@ -6,9 +6,10 @@
 
 #include <cassert>
 
-SoundInstance::SoundInstance(uint32_t _soundID, AudioSystem* _audioSystem) :
+SoundInstance::SoundInstance(uint32_t _soundID, AudioSystem* _audioSystem,float _sampleRate) :
     soundID_(_soundID),
-    audioSystem_(_audioSystem)
+    audioSystem_(_audioSystem),
+    sampleRate_(_sampleRate)
 {
 }
 
@@ -50,8 +51,8 @@ std::shared_ptr<VoiceInstance> SoundInstance::Play(float _volume, bool _loop, bo
 
     pSourceVoice->SetVolume(_volume);
 
-    auto voiceInstance = std::make_shared<VoiceInstance>(pSourceVoice, _volume);
-    voiceInstance->Play();
+    auto voiceInstance = std::make_shared<VoiceInstance>(pSourceVoice, _volume, sampleRate_);
+        voiceInstance->Play();
 
     voiceInstance_.push_back(voiceInstance);
 

--- a/Engine/System/Audio/SoundInstance.h
+++ b/Engine/System/Audio/SoundInstance.h
@@ -13,7 +13,7 @@ class SoundInstance
 {
 public:
 
-    SoundInstance(uint32_t _soundID, AudioSystem* _audioSystem);
+    SoundInstance(uint32_t _soundID, AudioSystem* _audioSystem, float _sampleRate);
     ~SoundInstance();
 
     std::shared_ptr<VoiceInstance> Play(float _volume = 1.0f, bool _loop = false, bool _enableOverlap = true);
@@ -22,6 +22,8 @@ private:
 
     AudioSystem* audioSystem_;
     uint32_t soundID_;
+
+    float sampleRate_;
 
     std::vector<std::weak_ptr<VoiceInstance>> voiceInstance_;
 

--- a/Engine/System/Audio/VoiceInstance.cpp
+++ b/Engine/System/Audio/VoiceInstance.cpp
@@ -2,9 +2,10 @@
 
 #include <Debug/Debug.h>
 
-VoiceInstance::VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume) :
+VoiceInstance::VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume, float _sampleRate) :
     sourceVoice_(_sourceVoice),
-    volume_(_volume)
+    volume_(_volume),
+    sampleRate_(_sampleRate)
 {
     if (!sourceVoice_)
     {
@@ -83,3 +84,11 @@ void VoiceInstance::SetVolume(float _volume)
         volume_ = _volume;
     }
 }
+
+float VoiceInstance::GetElapsedTime() const
+{
+    XAUDIO2_VOICE_STATE state;
+    sourceVoice_->GetState(&state);
+    return static_cast<float>(state.SamplesPlayed) / sampleRate_; // Assuming 44100 Hz sample rate
+}
+

--- a/Engine/System/Audio/VoiceInstance.h
+++ b/Engine/System/Audio/VoiceInstance.h
@@ -5,7 +5,7 @@
 class VoiceInstance
 {
 public:
-    VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume = 1.0f);
+    VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume = 1.0f, float _sampleRate = 44100.0f);
     ~VoiceInstance() = default;
 
     void Play();
@@ -22,6 +22,8 @@ public:
     bool IsPlaying() const { return isPlaying_; }
     bool IsPaused() const { return isPaused_; }
 
+    float GetElapsedTime() const;
+
 
 private:
 
@@ -31,6 +33,7 @@ private:
     bool isFadingIn_ = false;
 
     float volume_ = 1.0f;
+    float sampleRate_ = 44100.0f; // サンプルレート
 
     IXAudio2SourceVoice* sourceVoice_ = nullptr;
 


### PR DESCRIPTION
それに伴い，bpmを各メンバに持つように。

オーディオシステムの改善

`AudioSystem` と `SoundInstance` のインスタンス生成時にサンプルレートを渡すように変更しました。`VoiceInstance` クラスに再生時間を取得するメソッドを追加し、サンプルレートをメンバー変数として持つようにしました。また、必要なファイルのコンパイル設定を追加しました。