### PR TITLE
サウンドインスタンスのサンプルレート取得を修正

### DIFF
--- a/Engine/System/Audio/AudioSystem.cpp
+++ b/Engine/System/Audio/AudioSystem.cpp
@@ -138,9 +138,10 @@ std::shared_ptr<SoundInstance> AudioSystem::Load(const std::string& _filename)
     pathToid_[_filename] = soundId;
 
     Debug::Log("\tID : " + std::to_string(soundId) + "\n");
+    float sampleRate = static_cast<float>(soundData.wfex.nSamplesPerSec);
 
-    auto soundindtance = std::make_shared<SoundInstance>(soundId, this, soundData.wfex.nSamplesPerSec);
-        soundInstances_[soundId] = soundindtance;
+    auto soundindtance = std::make_shared<SoundInstance>(soundId, this, sampleRate);
+    soundInstances_[soundId] = soundindtance;
 
     return soundindtance;
 }


### PR DESCRIPTION
`AudioSystem::Load` メソッド内で、`SoundInstance` の作成時に使用されるサンプルレートの取得方法を変更しました。`soundData.wfex.nSamplesPerSec` から `sampleRate` 変数を介して取得するように修正し、コードの可読性を向上させました。