### PR TITLE
音声ファイルの再生時間取得関数を実装，途中から再生するを開始するオーバーロード関数を実装

### DIFF
--- a/Engine/System/Audio/SoundInstance.h
+++ b/Engine/System/Audio/SoundInstance.h
@@ -16,8 +16,16 @@ public:
     SoundInstance(uint32_t _soundID, AudioSystem* _audioSystem, float _sampleRate);
     ~SoundInstance();
 
-    std::shared_ptr<VoiceInstance> GenerateVoiceInstance(float _volume = 1.0f, bool _loop = false, bool _enableOverlap = true);
-    std::shared_ptr<VoiceInstance> Play(float _volume = 1.0f, bool _loop = false, bool _enableOverlap = true);
+    std::shared_ptr<VoiceInstance> GenerateVoiceInstance(float _volume = 1.0f, float _startTime = 0.0f, bool _loop = false, bool _enableOverlap = true);
+
+    std::shared_ptr<VoiceInstance> Play(float _volume, bool _loop = false, bool _enableOverlap = true);
+    std::shared_ptr<VoiceInstance> Play(float _volume, float _startTime, bool _loop = false, bool _enableOverlap = true);
+
+    /// <summary>
+    /// 音声ファイルの再生時間を取得
+    /// </summary>
+    /// <returns>再生時間(秒)</returns>
+    float GetDuration() const;
 
 private:
 


### PR DESCRIPTION
音声再生機能の拡張

`SoundInstance` クラスの `GenerateVoiceInstance` メソッドに `_startTime` 引数を追加し、音声の再生開始時間を指定できるようにしました。また、`Play` メソッドもオーバーロードされ、指定した時間から音声を再生できるようになりました。さらに、`GetDuration` メソッドを追加し、音声ファイルの再生時間を取得可能にしました。