### PR TITLE
VoiceInstance::GetElapseTimeを修正

### DIFF
--- a/Engine/System/Audio/SoundInstance.cpp
+++ b/Engine/System/Audio/SoundInstance.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<VoiceInstance> SoundInstance::GenerateVoiceInstance(float _volum
 
     pSourceVoice->SetVolume(_volume);
 
-    auto voiceInstance = std::make_shared<VoiceInstance>(pSourceVoice, _volume, sampleRate_);
+    auto voiceInstance = std::make_shared<VoiceInstance>(pSourceVoice, _volume, sampleRate_, _startTime);
 
     voiceInstance_.push_back(voiceInstance);
 

--- a/Engine/System/Audio/VoiceInstance.cpp
+++ b/Engine/System/Audio/VoiceInstance.cpp
@@ -2,10 +2,13 @@
 
 #include <Debug/Debug.h>
 
-VoiceInstance::VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume, float _sampleRate) :
+VoiceInstance::VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume, float _sampleRate, float _startTime) :
     sourceVoice_(_sourceVoice),
     volume_(_volume),
-    sampleRate_(_sampleRate)
+    sampleRate_(_sampleRate),
+    startTime_(_startTime),
+    isPaused_(false),
+    hr_(S_OK)
 {
     if (!sourceVoice_)
     {
@@ -113,7 +116,7 @@ float VoiceInstance::GetElapsedTime() const
 {
     XAUDIO2_VOICE_STATE state;
     sourceVoice_->GetState(&state);
-    return static_cast<float>(state.SamplesPlayed) / sampleRate_;
+    return static_cast<float>(state.SamplesPlayed) / sampleRate_ + startTime_;
 }
 
 void VoiceInstance::CheckHRESULT() const

--- a/Engine/System/Audio/VoiceInstance.h
+++ b/Engine/System/Audio/VoiceInstance.h
@@ -5,7 +5,7 @@
 class VoiceInstance
 {
 public:
-    VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume = 1.0f, float _sampleRate = 44100.0f);
+    VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume = 1.0f, float _sampleRate = 44100.0f, float _startTime = 0.0f);
     ~VoiceInstance() = default;
 
     /// <summary>
@@ -71,6 +71,11 @@ public:
     /// <returns>経過時間(秒)</returns>
     float GetElapsedTime() const;
 
+    /// <summary>
+    /// 再生開始時間を取得
+    /// </summary>
+    /// <returns>再生開始時間(秒)</returns>
+    float GetStartTime() const { return startTime_; }
 
 private:
     /// <summary>
@@ -86,6 +91,9 @@ private:
 
     // 音量
     float volume_ = 1.0f;
+
+    // 再生開始時間
+    float startTime_ = 0.0f;
 
     // サンプルレート
     float sampleRate_ = 44100.0f;


### PR DESCRIPTION
曲の再生開始時間

VoiceInstanceに再生開始時間を追加

`SoundInstance.cpp` の `GenerateVoiceInstance` メソッドを修正し、`VoiceInstance` のコンストラクタに `_startTime` 引数を追加しました。これにより、生成される `VoiceInstance` に再生開始時間を指定できるようになりました。

`VoiceInstance.cpp` では、コンストラクタに `_startTime` 引数を追加し、`startTime_` メンバー変数を初期化しました。また、`GetElapsedTime` メソッドを修正し、経過時間の計算に `startTime_` を加算しました。

`VoiceInstance.h` では、コンストラクタに `_startTime` 引数を追加し、再生開始時間を取得する `GetStartTime` メソッドを新たに追加しました。さらに、プライベートメンバーに `startTime_` を追加し、初期値を設定しました。