### PR TITLE
再生速度設定機能を追加

### DIFF
--- a/Engine/System/Audio/VoiceInstance.cpp
+++ b/Engine/System/Audio/VoiceInstance.cpp
@@ -119,6 +119,16 @@ float VoiceInstance::GetElapsedTime() const
     return static_cast<float>(state.SamplesPlayed) / sampleRate_ + startTime_;
 }
 
+void VoiceInstance::SetPlaySpeed(float _speed)
+{
+    if (sourceVoice_)
+    {
+        hr_ = sourceVoice_->SetFrequencyRatio(_speed);
+        CheckHRESULT();
+        playSpeed_ = _speed;
+    }
+}
+
 void VoiceInstance::CheckHRESULT() const
 {
     if (FAILED(hr_))

--- a/Engine/System/Audio/VoiceInstance.h
+++ b/Engine/System/Audio/VoiceInstance.h
@@ -77,6 +77,19 @@ public:
     /// <returns>再生開始時間(秒)</returns>
     float GetStartTime() const { return startTime_; }
 
+
+    /// <summary>
+    /// 再生速度を設定
+    /// </summary>
+    /// <param name="_speed">1.0f で通常速度</param>
+    void SetPlaySpeed(float _speed);
+
+    /// <summary>
+    /// 再生速度を取得
+    /// </summary>
+    /// <returns>再生速度</returns>
+    float GetPlaySpeed() const { return playSpeed_; }
+
 private:
     /// <summary>
     /// HRESULTをチェックし、エラーがあれば例外を投げる
@@ -97,6 +110,8 @@ private:
 
     // サンプルレート
     float sampleRate_ = 44100.0f;
+
+    float playSpeed_ = 1.0f; // 再生速度
 
     // 音声ソースボイス
     IXAudio2SourceVoice* sourceVoice_ = nullptr;


### PR DESCRIPTION
`VoiceInstance` クラスに `SetPlaySpeed` メソッドを追加し、再生速度を設定できるようにしました。これに伴い、`GetPlaySpeed` メソッドも追加され、現在の再生速度を取得可能です。プライベートメンバー変数に `playSpeed_` を追加し、初期値を `1.0f` に設定しました。全体的に再生速度に関連する機能が強化されました。