### PR TITLE
デバッグウィンドウの管理とテクスチャ処理の改善

### DIFF
--- a/Engine/Core/DXCommon/TextureManager/TextureManager.h
+++ b/Engine/Core/DXCommon/TextureManager/TextureManager.h
@@ -48,13 +48,15 @@ private:
     };
 
     std::unordered_map<std::string, uint32_t> keys_ = {};
-    std::map<uint32_t, Texture> textures_ = {};
+    std::unordered_map<uint32_t, Texture> textures_ = {};
+
+    bool needSort_ = false; // ソートが必要かどうか
 
     TextureManager();
     ~TextureManager();
     TextureManager(const TextureManager&) = delete;
     TextureManager operator=(const TextureManager&) = delete;
 
-    void ImGui();
+    void ImGui(bool* _open);
 
 };

--- a/Engine/Debug/ImGuiDebugManager.h
+++ b/Engine/Debug/ImGuiDebugManager.h
@@ -19,6 +19,18 @@ public:
     void Initialize();
     void ShowDebugWindow();
 
+    void BeginFrame();
+
+    void EndFrame();
+
+    /// <summary>
+    /// デバッグウィンドウを開始する
+    /// </summary>
+    /// <param name="_name">window名</param>
+    /// <param name="_flags">ImGuiWindowFlags </param>
+    /// <returns> ウィンドウが開始されたかどうか </returns>
+    bool Begin(const std::string& _name = "DebugWindow", ImGuiWindowFlags _flags = ImGuiWindowFlags_None);
+
     /// <summary>
     /// デバッグウィンドウを追加する
     /// </summary>
@@ -42,6 +54,12 @@ public:
     std::string AddColliderDebugWindow(const std::string& _name, std::function<void()> _func);
 
 
+    bool RegisterMenuItem(const std::string& _name, std::function<void(bool*)> _func);
+
+private:
+
+    void MenuBar();
+
 
 private:
 #ifdef _DEBUG
@@ -54,8 +72,21 @@ private:
     std::vector<uint8_t> colliderIsSelect_;
 
 
-    ImGuiDebugManager() = default;
-    ~ImGuiDebugManager() = default;
+    bool isDemoWindowVisible_ = false;
+    bool isIDStackToolVisible_ = false;
+    //bool isStyleEditorVisible_ = false;
+
+    std::map<std::string, std::function<void(bool*)>> menuItems_;
+
+    std::map<std::string, bool> menuItemsVisibility_;
+    std::map<std::string, bool> windowsVisibility_;
+
+    // すべてのウィンドウを隠すか
+    bool isAllWindowHidden_ = false;
+
+private:
+    ImGuiDebugManager();
+    ~ImGuiDebugManager();
 
     // コピー禁止
     ImGuiDebugManager(const ImGuiDebugManager&) = delete;

--- a/Engine/Debug/ImGuiManager.cpp
+++ b/Engine/Debug/ImGuiManager.cpp
@@ -50,16 +50,12 @@ void ImGuiManager::Begin()
 
     ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(),ImGuiDockNodeFlags_PassthruCentralNode);
 
-    ImGui::Begin("Engine");
-
-
 #endif // _DEBUG
 }
 
 void ImGuiManager::End()
 {
 #ifdef _DEBUG
-    ImGui::End();
     ImGui::Render();
 #endif // _DEBUG
 }

--- a/Engine/Features/Collision/Manager/CollisionManager.cpp
+++ b/Engine/Features/Collision/Manager/CollisionManager.cpp
@@ -279,9 +279,11 @@ void CollisionManager::DrawColliders()
     }
 }
 
-void CollisionManager::ImGui()
+void CollisionManager::ImGui(bool* _open)
 {
 #ifdef _DEBUG
+    ImGui::Begin("CollisionManager", _open);
+
     ImGui::PushID(this);
 
     // デバッグ描画の有効/無効を設定
@@ -294,6 +296,8 @@ void CollisionManager::ImGui()
     ImGui::Text("Active Collisions: %zu", collisionPairs_.size());
 
     ImGui::PopID();
+
+    ImGui::End();
 #endif // _DEBUG
 }
 
@@ -360,6 +364,6 @@ CollisionManager::CollisionManager()
     : isDrawEnabled_(true)
 {
 #ifdef _DEBUG
-    ImGuiDebugManager::GetInstance()->AddColliderDebugWindow("CollisionManager", [&]() {ImGui(); });
+    ImGuiDebugManager::GetInstance()->RegisterMenuItem("CollisionManager", [this](bool* _open) { ImGui(_open); });
 #endif // DEBUG
 }

--- a/Engine/Features/Collision/Manager/CollisionManager.h
+++ b/Engine/Features/Collision/Manager/CollisionManager.h
@@ -50,7 +50,7 @@ public:
     void UnregisterCollider(Collider* _collider);
 
     // デバッグUI
-    void ImGui();
+    void ImGui(bool* _oopen);
 
 private:
     // 衝突応答を実行する

--- a/Engine/Features/Scene/Manager/SceneManager.cpp
+++ b/Engine/Features/Scene/Manager/SceneManager.cpp
@@ -1,8 +1,7 @@
 #include <Features/Scene/Manager/SceneManager.h>
-#include <System/Input/Input.h>
-#include <System/Time/Time.h>
-#include <System/Time/GameTime.h>
-#include <System/Time/Time_MT.h>
+
+#include <Debug/ImGuiDebugManager.h>
+
 #include <cassert>
 
 SceneManager* SceneManager::GetInstance()
@@ -11,19 +10,26 @@ SceneManager* SceneManager::GetInstance()
     return &instance;
 }
 
+SceneManager::SceneManager()
+    : sceneFactory_(nullptr),
+    currentSceneName_("empty"),
+    nextSceneName_("empty"),
+    isTransition_(false)
+{
+#ifdef _DEBUG
+    ImGuiDebugManager::GetInstance()->RegisterMenuItem("SceneManager", [this](bool* _open) {ImGui(_open); });
+#endif // _DEBUG
+
+}
+
 SceneManager::~SceneManager()
 {
-    //scenes_.clear();
-    //currentScene_.reset();
+#ifdef _DEBUG
+    ImGuiDebugManager::GetInstance()->RemoveDebugWindow("SceneManager");
+#endif // _DEBUG
 
     delete sceneFactory_;
 }
-//
-//void SceneManager::RegisterScene(const std::string& _name, SceneFactory _scene)
-//{
-//    auto instance = GetInstance();
-//    //instance->scenes_[_name] = _scene;
-//}
 
 void SceneManager::SetSceneFactory(ISceneFactory* _sceneFactory)
 {
@@ -46,9 +52,6 @@ void SceneManager::Update()
 {
     assert(sceneFactory_ != nullptr);
 
-#ifdef _DEBUG
-    ImGui();
-#endif // _DEBUG
     currentScene_->Update();
 
     if(!transitionQueue_.empty())
@@ -161,11 +164,28 @@ void SceneManager::Finalize()
 
 #ifdef _DEBUG
 #include <imgui.h>
-void SceneManager::ImGui()
+void SceneManager::ImGui(bool* _open)
 {
-    //char comboLabel[128];
+    ImGui::Begin("SceneManager", _open);
+    {
+        ImGui::Text("Current Scene : %s", currentSceneName_.c_str());
 
-    ImGui::Begin("SceneManager");
+        std::string name = sceneFactory_->ShowDebugWindow();
+        if (!name.empty())
+        {
+            ReserveScene(name, nullptr);
+        }
+
+        ImGui::Text("-----Transition-----");
+        ImGui::Text("Transitioning : %s", isTransition_ ? "true" : "false");
+    }
+    ImGui::End();
+}
+#endif // _DEBUG
+
+
+/*
+
     ImGui::SeparatorText("TIME_MT");
     ImGui::Text("Frametate: %.3f fps", Time_MT::GetFramerate());
     ImGui::Text("DeltaTime: %4.2f ms", Time_MT::GetDeltaTime<double>() * 1000.0);
@@ -178,17 +198,4 @@ void SceneManager::ImGui()
 
     ImGui::Text("Frametate: %.3f fps", GameTime::GetInstance()->GetFramerate());
     ImGui::Text("DeltaTime: %4.2f ms", GameTime::GetInstance()->GetDeltaTime() * 1000.0);
-
-    std::string name = sceneFactory_->ShowDebugWindow();
-    if (!name.empty())
-    {
-        ReserveScene(name, nullptr);
-    }
-
-
-    ImGui::Text("Current Scene : %s", currentSceneName_.c_str());
-
-
-    ImGui::End();
-}
-#endif // _DEBUG
+*/

--- a/Engine/Features/Scene/Manager/SceneManager.h
+++ b/Engine/Features/Scene/Manager/SceneManager.h
@@ -4,10 +4,8 @@
 #include <Features/Scene/Interface/ISceneTransition.h>
 #include <Features/Scene/SceneData.h>
 
-#include <iostream>
 #include <cstdint>
 #include <string>
-#include <unordered_map>
 #include <memory>
 #include <queue>
 
@@ -17,54 +15,49 @@ class SceneManager
 public:
     static SceneManager* GetInstance();
 
-    ~SceneManager();
-
-    // シーンの登録
-    // _name : シーンの名前
-    // _scene : シーンの生成関数
-    // 例 : SceneManager::RegisterScene("game", Game::Create);
-    //static void RegisterScene(const std::string& _name, SceneFactory _scene);
-
-    // シーンファクトリの設定
-    void SetSceneFactory(ISceneFactory* _sceneFactory);
-
     // 初期化
-    // _name : 初期化するシーンの名前
+    // _name : 初期化するシーンの名前 ファクトリ参照
     void Initialize(const std::string& _name);
     // 更新
     void Update();
     // 描画
     void Draw();
-
+    // 影の描画
     void DrawShadow();
 
+    // シーンの遷移を設定
     void SetTransition(std::unique_ptr<ISceneTransition> _transition);
 
+    // シーンファクトリの設定
+    void SetSceneFactory(ISceneFactory* _sceneFactory);
+
     // シーンの予約
-    // _name : 予約するシーンの名前
+    // _name : 予約するシーンの名前 ファクトリ参照
     static void ReserveScene(const std::string& _name, std::unique_ptr<SceneData> _sceneData);
 
     // シーンの変更
     static void ChangeScene();
 
+    // 終了処理
     void Finalize();
 
 private:
+    // シーンファクトリ
     ISceneFactory* sceneFactory_ = nullptr;
-
-    // シーンのリスト
-    //std::unordered_map<std::string, SceneFactory>   scenes_ = {};
-    //SceneFactory nextScene_ = nullptr;
 
     // 現在のシーン
     std::unique_ptr<BaseScene> currentScene_ = nullptr;
 
+    // シーンの遷移
     std::unique_ptr<ISceneTransition> transition_ = nullptr;
 
+    // シーン間の受け渡しデータ
     std::unique_ptr<SceneData> sceneData_ = nullptr;
 
+    // シーンの遷移中かどうか
     bool isTransition_ = false;
 
+    // シーンの遷移を待機するキュー
     std::queue<std::unique_ptr<ISceneTransition>> transitionQueue_ = {};
 
     // 現在のシーン名
@@ -73,11 +66,15 @@ private:
     std::string nextSceneName_ = {};
 
 #ifdef _DEBUG
-    void ImGui();
+    void ImGui(bool* _open);
 #endif // _DEBUG
 
 
-    SceneManager() = default;
+private:
+    // コンストラクタとデストラクタ
+    SceneManager();
+    ~SceneManager();
+
     // コピー禁止
     SceneManager(const SceneManager&) = delete;
     SceneManager& operator=(const SceneManager&) = delete;

--- a/Engine/Framework/Framework.cpp
+++ b/Engine/Framework/Framework.cpp
@@ -39,20 +39,20 @@ void Framework::Initialize(const std::wstring& _winTitle)
     srvManager_->Initialize();
 
 
+#ifdef _DEBUG
+    ImGuiDebugManager::GetInstance()->Initialize();
+#endif
+    imguiManager_ = new ImGuiManager();
+    imguiManager_->Initialize();
 
     rtvManager_ = RTVManager::GetInstance();
     rtvManager_->Initialize(dxCommon_->GetBackBufferSize(), WinApp::kWindowWidth_, WinApp::kWindowHeight_);
 
-#ifdef _DEBUG
-    ImGuiDebugManager::GetInstance()->Initialize();
-#endif
 
     PSOManager::GetInstance()->Initialize();
 
     LightingSystem::GetInstance()->Initialize();
 
-    imguiManager_ = new ImGuiManager();
-    imguiManager_->Initialize();
 
     TextureManager* instance = TextureManager::GetInstance();
     instance->Initialize();
@@ -99,11 +99,10 @@ void Framework::Update()
     {
         endRequest_ = true;
     }
+    imguiManager_->Begin();
 
     // フレーム始め
-    imguiManager_->Begin();
     TextRenderer::GetInstance()->BeginFrame();
-    ImGuiDebugManager::GetInstance()->ShowDebugWindow();
 
     Time::Update();
 
@@ -118,6 +117,10 @@ void Framework::PreDraw()
 
 void Framework::PostDraw()
 {
+#ifdef _DEBUG
+    ImGuiDebugManager::GetInstance()->ShowDebugWindow();
+#endif // _DEBUG
+
     imguiManager_->End();
     imguiManager_->Draw();
 

--- a/Engine/System/Input/Input.h
+++ b/Engine/System/Input/Input.h
@@ -94,13 +94,11 @@ public:
     /// <param name="_deadZone">: 0 ~ 1 </param>
     void SetTriggerDeadZone(float _deadZone);
 
-    bool IsControllerConnected() {
-        XINPUT_STATE state; ZeroMemory(&state, sizeof(XINPUT_STATE));
-        // コントローラの状態を取得
-        DWORD result = XInputGetState(0, &state);
-        // コントローラが接続されている場合は true を返す
-        return (result == ERROR_SUCCESS);
-    }
+    /// <summary>
+    /// コントローラーが接続されているかどうかを確認
+    /// </summary>
+    /// <returns></returns>
+    bool IsControllerConnected();
 
 private:
 	Microsoft::WRL::ComPtr <IDirectInput8> directInput_ = nullptr;
@@ -136,12 +134,21 @@ private:
 
 	WinApp* winApp_ = nullptr;
 
+private:
+    // コピーコンストラクタ
+    Input();
+    ~Input() = default;
+    //代入演算子を削除
+    Input(const Input&) = delete;
+    Input& operator=(const Input&) = delete;
+
+
 #ifdef _DEBUG
     float leftMotorSpeed_ = 0.0f;
     float rightMotorSpeed_ = 0.0f;
     float vibrateTime_ = 0.0f;
 
-    void ImGui();
+    void ImGui(bool* _open);
 #endif // _DEBUG
 
 };

--- a/Engine/System/Time/Time.cpp
+++ b/Engine/System/Time/Time.cpp
@@ -1,4 +1,5 @@
 #include <System/Time/Time.h>
+#include <Debug/ImGuiDebugManager.h>
 #include <chrono>
 
 double  Time::deltaTime_                = 1.0f / 60.0f;
@@ -23,6 +24,10 @@ void Time::Initialize()
     defaultFramerate_ = 60.0f;
     isDeltaTimeFixed_ = true;
     frameCount_ = 0;
+
+#ifdef _DEBUG
+    ImGuiDebugManager::GetInstance()->RegisterMenuItem("TimeInfo", [](bool* _open) { ImGui(_open); });
+#endif // _DEBUG
 }
 
 void Time::Update()
@@ -66,3 +71,17 @@ double Time::GetCurrentTime()
     // 秒単位に変換して返す
     return static_cast<float>(duration.count()) / 1000.0f;
 }
+
+#ifdef _DEBUG
+void Time::ImGui(bool* _open)
+{
+    ImGui::Begin("Time Info", _open);
+    {
+        ImGui::Text("Framerate: %.3f fps", GetFramerate());
+        ImGui::Text("DeltaTime: %.4f ms", GetDeltaTime<double>() * 1000.0);
+        ImGui::Text("CurrentTime: %.2f s", GetCurrentTime());
+        ImGui::Checkbox("Fixed DeltaTime", &isDeltaTimeFixed_);
+    }
+    ImGui::End();
+}
+#endif // _DEBUG

--- a/Engine/System/Time/Time.h
+++ b/Engine/System/Time/Time.h
@@ -72,6 +72,9 @@ public:
     */
     static bool IsDeltaTimeFixed() { return isDeltaTimeFixed_; }
 
+#ifdef _DEBUG
+    static void ImGui(bool* _open);
+#endif // _DEBUG
 private:
 
     static double deltaTime_;           ///<! デルタタイム

--- a/Sample/Resources/Shader/TextRenderer.hlsl
+++ b/Sample/Resources/Shader/TextRenderer.hlsl
@@ -12,17 +12,25 @@ struct VSOutput
     float4 color : COLOR;
 };
 
-VSOutput VSmain(VSInput input)
+cbuffer ViewProjection : register(b0)
 {
+    float4x4 orthoMat;
+}
+StructuredBuffer<float4x4> worldMatrices : register(t0);
+
+VSOutput VSmain(VSInput input, uint vertexID : SV_VertexID)
+{
+    uint matrixIndex = vertexID / 6; // 頂点番号からワールド行列のインデックスを計算 六頂点で構成している
+
     VSOutput output;
-    output.position = input.position;
+    output.position = mul(input.position, mul(worldMatrices[matrixIndex], orthoMat));
     output.texCoord = input.texCoord;
     output.color = input.color;
     return output;
 }
 
 
-Texture2D<float> fontTexture : register(t0);
+Texture2D<float> fontTexture : register(t1);
 SamplerState fontSampler : register(s0);
 
 struct PSInput

--- a/Sample/SampleScene.cpp
+++ b/Sample/SampleScene.cpp
@@ -132,6 +132,7 @@ void SampleScene::Update()
     {
         ImGui::Begin("Engine");
         {
+            static float volume = 1.0f;
             // サウンドの再生
             if (ImGui::Button("play Sound"))
             {
@@ -139,11 +140,10 @@ void SampleScene::Update()
                 {
                     // 返り値で VoiceInstanceを受け取る
                     // これを使用して音量やピッチの変更ができる
-                    voiceInstance_ = soundInstance_->Play();
+                    voiceInstance_ = soundInstance_->Play(volume);
                 }
             }
 
-            static float volume = 1.0f;
             if (ImGui::DragFloat("Volume", &volume, 0.0f, 1.0f))
             {
                 if (voiceInstance_)

--- a/Sample/deveScene/DeveScene.cpp
+++ b/Sample/deveScene/DeveScene.cpp
@@ -10,7 +10,7 @@
 #include <Features/Collision/Manager/CollisionManager.h>
 #include <Features/PostEffects/DepthBasedOutLine.h>
 
-#include <Debug/ImGuiManager.h>
+#include <Debug/ImGuiDebugManager.h>
 #include <Debug/ImGuiHelper.h>
 #include  <Core/DXCommon/DXCommon.h>
 
@@ -168,20 +168,20 @@ void DeveScene::Update()
 
 
     {
-        ImGui::Begin("Engine");
+        if(ImGuiDebugManager::GetInstance()->Begin("Engine"))
         {
             // サウンドの再生
+            static float volume = 1.0f;
             if (ImGui::Button("play Sound"))
             {
                 if (soundInstance_)
                 {
                     // 返り値で VoiceInstanceを受け取る
                     // これを使用して音量やピッチの変更ができる
-                    voiceInstance_ = soundInstance_->Play();
+                    voiceInstance_ = soundInstance_->Play(volume);
                 }
             }
 
-            static float volume = 1.0f;
             if (ImGui::DragFloat("Volume", &volume, 0.0f, 1.0f))
             {
                 if (voiceInstance_)
@@ -197,10 +197,10 @@ void DeveScene::Update()
                     voiceInstance_ = nullptr; // VoiceInstanceを解放
                 }
             }
+            ImGui::End();
         }
 
 
-        ImGui::End();
 
         // light調整用
         lights_->ImGui();

--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -1,10 +1,10 @@
 [Window][Debug##Default]
-Pos=60,58
-Size=400,400
+Pos=521,299
+Size=400,166
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=709,11
+Pos=266,47
 Size=550,674
 Collapsed=0
 
@@ -54,10 +54,9 @@ Size=248,338
 Collapsed=0
 
 [Window][Engine]
-Pos=17,18
-Size=15,19
+Pos=521,92
+Size=298,173
 Collapsed=0
-DockId=0x00000009,0
 
 [Window][CatmulRom]
 Pos=56,266
@@ -95,16 +94,14 @@ Size=158,59
 Collapsed=0
 
 [Window][Input]
-Pos=17,18
-Size=15,19
+Pos=156,338
+Size=384,271
 Collapsed=0
-DockId=0x00000009,2
 
 [Window][SceneManager]
-Pos=17,18
-Size=15,19
+Pos=725,167
+Size=197,166
 Collapsed=0
-DockId=0x00000009,1
 
 [Window][ParticleTestScene]
 Pos=0,12
@@ -135,16 +132,16 @@ Collapsed=0
 DockId=0x00000001,2
 
 [Window][DebugWindow]
-Pos=25,0
-Size=7,19
+Pos=17,19
+Size=15,19
 Collapsed=0
-DockId=0x00000008,0
+DockId=0x0000000B,1
 
 [Window][Debug]
-Pos=17,0
-Size=6,19
+Pos=17,19
+Size=15,19
 Collapsed=0
-DockId=0x00000007,0
+DockId=0x0000000B,0
 
 [Window][GradientEditor]
 Pos=60,60
@@ -157,7 +154,7 @@ Size=612,159
 Collapsed=0
 
 [Window][WindowOverViewport_11111111]
-Pos=0,0
+Pos=0,19
 Size=32,32
 Collapsed=0
 
@@ -174,10 +171,10 @@ Collapsed=0
 DockId=0x0000000F,0
 
 [Window][Light Settings]
-Pos=17,26
+Pos=17,37
 Size=15,19
 Collapsed=0
-DockId=0x0000000D,0
+DockId=0x0000000C,0
 
 [Window][TimeLine]
 Pos=0,17
@@ -198,14 +195,29 @@ Collapsed=0
 DockId=0x0000000A,1
 
 [Window][Post Effect Manager]
-Pos=17,26
+Pos=17,37
 Size=15,19
 Collapsed=0
-DockId=0x0000000D,1
+DockId=0x0000000C,1
 
 [Window][TextureManager]
-Pos=128,0
-Size=337,150
+Pos=14,250
+Size=394,250
+Collapsed=0
+
+[Window][Dear ImGui ID Stack Tool]
+Pos=88,140
+Size=612,148
+Collapsed=0
+
+[Window][Time Info]
+Pos=628,368
+Size=202,104
+Collapsed=0
+
+[Window][CollisionManager]
+Pos=716,56
+Size=207,122
 Collapsed=0
 
 [Table][0xC9935533,3]
@@ -259,19 +271,15 @@ Column 2  Width=56
 
 [Docking][Data]
 DockNode          ID=0x00000001 Pos=255,18 Size=325,299 Selected=0x52D7A061
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
-  DockNode        ID=0x00000005 Parent=0x08BD597D SizeRef=930,720 Split=Y
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=X
+  DockNode        ID=0x00000005 Parent=0x08BD597D SizeRef=980,720 Split=Y
     DockNode      ID=0x00000002 Parent=0x00000005 SizeRef=1280,463 Split=Y
       DockNode    ID=0x00000003 Parent=0x00000002 SizeRef=1042,412 Split=Y
-        DockNode  ID=0x0000000E Parent=0x00000003 SizeRef=930,481 CentralNode=1
+        DockNode  ID=0x0000000E Parent=0x00000003 SizeRef=930,481 CentralNode=1 Selected=0x1FDCDEE6
         DockNode  ID=0x0000000F Parent=0x00000003 SizeRef=930,237 Selected=0x5879BBFD
       DockNode    ID=0x0000000A Parent=0x00000002 SizeRef=1042,306 Selected=0x42899545
     DockNode      ID=0x00000004 Parent=0x00000005 SizeRef=1280,255 Selected=0x4F89F0DC
-  DockNode        ID=0x00000006 Parent=0x08BD597D SizeRef=348,720 Split=Y Selected=0x4B6712B0
-    DockNode      ID=0x0000000B Parent=0x00000006 SizeRef=88,377 Split=X Selected=0x1E7E18E3
-      DockNode    ID=0x00000007 Parent=0x0000000B SizeRef=129,210 Selected=0x1E7E18E3
-      DockNode    ID=0x00000008 Parent=0x0000000B SizeRef=217,210 Selected=0x4B6712B0
-    DockNode      ID=0x0000000C Parent=0x00000006 SizeRef=88,341 Split=Y Selected=0xAC437A35
-      DockNode    ID=0x00000009 Parent=0x0000000C SizeRef=348,178 Selected=0xAC437A35
-      DockNode    ID=0x0000000D Parent=0x0000000C SizeRef=348,161 Selected=0xB5453E4F
+  DockNode        ID=0x00000006 Parent=0x08BD597D SizeRef=298,720 Split=Y Selected=0x4B6712B0
+    DockNode      ID=0x0000000B Parent=0x00000006 SizeRef=88,377 Selected=0x1E7E18E3
+    DockNode      ID=0x0000000C Parent=0x00000006 SizeRef=88,341 Selected=0xB5453E4F
 


### PR DESCRIPTION
TextureManager.cppにて、テクスチャ読み込み後のソートフラグを追加し、デバッグウィンドウの登録方法を変更しました。また、ImGuiメソッドにウィンドウのオープン状態を管理する引数を追加しました。

ImGuiDebugManager.cppおよび.hにて、デバッグウィンドウの初期化とクリーンアップを行うコンストラクタとデストラクタを追加し、メニューアイテムの表示ロジックを実装しました。

CollisionManager.cppおよびSceneManager.cppで、ImGuiメソッドにウィンドウのオープン状態を管理する引数を追加しました。

Framework.cppでデバッグマネージャの初期化を追加し、Input.cppおよびTime.cppでもImGuiメソッドにオープン状態を管理する引数を追加しました。

imgui.iniでは、ウィンドウの位置やサイズを調整し、デバッグウィンドウのレイアウトを改善しました。