### PR TITLE
ライトとpostEffectを隠せるように

### DIFF
--- a/Engine/Features/Light/Group/LightGroup.cpp
+++ b/Engine/Features/Light/Group/LightGroup.cpp
@@ -1,4 +1,5 @@
 #include "LightGroup.h"
+#include <Debug/ImGuiDebugManager.h> 
 
 uint32_t LightGroup::shadowMapSize_ = 4096;
 
@@ -196,7 +197,7 @@ void LightGroup::ImGui()
 {
 #ifdef _DEBUG
 
-    ImGui::Begin("Light Settings"); 
+    if(ImGuiDebugManager::GetInstance()->Begin("LightGroup"))
     {
         if (ImGui::CollapsingHeader("Light Group Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
             ImGui::Checkbox("Enable Directional Light", &enableDirectionalLight_);
@@ -216,8 +217,8 @@ void LightGroup::ImGui()
             DrawSpotLightsImGui();
         }
 
+        ImGui::End();
     }
-    ImGui::End();
 #endif // _DEBUG
 }
 

--- a/Sample/SampleFramework.cpp
+++ b/Sample/SampleFramework.cpp
@@ -1,6 +1,7 @@
 #include "SampleFramework.h"
 
 #include "SampleScene.h"
+#include <Debug/ImGuiDebugManager.h>
 #include <Features/Scene/ParticleTestScene.h>
 #include <Features/PostEffects/DepthBasedOutLine.h>
 #include <Features/PostEffects/Dissolve.h>
@@ -171,99 +172,100 @@ void SampleFramework::RenderUI()
     static int currentItem = 0;
 
     // ウィンドウを作成
-    ImGui::Begin("Post Effect Manager");
+    if(ImGuiDebugManager::GetInstance()->Begin("PostEffectManager"))
+    {
+        // エフェクト選択用コンボボックス
+        ImGui::Text("Select Effect:");
+        ImGui::Combo("##EffectCombo", &currentItem, availableEffects, numAvailableEffects);
 
-    // エフェクト選択用コンボボックス
-    ImGui::Text("Select Effect:");
-    ImGui::Combo("##EffectCombo", &currentItem, availableEffects, numAvailableEffects);
-
-    // エフェクト追加ボタン
-    if (ImGui::Button("Apply Effect")) {
-        // 選択されたエフェクトをアクティブリストに追加
-        std::string selectedEffect = availableEffects[currentItem];
-        activeEffects.push_back(selectedEffect);
-    }
-
-    ImGui::SameLine();
-
-    // エフェクトリストをクリアするボタン
-    if (ImGui::Button("Clear All")) {
-        activeEffects.clear();
-    }
-
-    // 現在アクティブなエフェクトの表示
-    ImGui::Separator();
-    ImGui::Text("Active Effects (in order):");
-
-    // 削除するエフェクトのインデックス (-1は削除なし)
-    static int effectToRemove = -1;
-
-    // アクティブエフェクトのリスト表示と管理
-    for (int i = 0; i < activeEffects.size(); i++) {
-        ImGui::PushID(i);
-
-        // エフェクト名の表示
-        ImGui::BulletText("%d: %s", i + 1, activeEffects[i].c_str());
-
-        ImGui::SameLine();
-
-        // エフェクトを上に移動するボタン
-        if (i > 0 && ImGui::Button("up")) {
-            std::swap(activeEffects[i], activeEffects[i - 1]);
+        // エフェクト追加ボタン
+        if (ImGui::Button("Apply Effect")) {
+            // 選択されたエフェクトをアクティブリストに追加
+            std::string selectedEffect = availableEffects[currentItem];
+            activeEffects.push_back(selectedEffect);
         }
 
         ImGui::SameLine();
 
-        // エフェクトを下に移動するボタン
-        if (i < activeEffects.size() - 1 && ImGui::Button("dowm")) {
-            std::swap(activeEffects[i], activeEffects[i + 1]);
+        // エフェクトリストをクリアするボタン
+        if (ImGui::Button("Clear All")) {
+            activeEffects.clear();
         }
 
-        ImGui::SameLine();
+        // 現在アクティブなエフェクトの表示
+        ImGui::Separator();
+        ImGui::Text("Active Effects (in order):");
 
-        // エフェクトを削除するボタン
-        if (ImGui::Button("X")) {
-            effectToRemove = i;
-        }
+        // 削除するエフェクトのインデックス (-1は削除なし)
+        static int effectToRemove = -1;
 
-        if (activeEffects[i] == "Dissolve")
-        {
-            static float threshold = 0.0f;
-            static Vector3 maskColor = { 0.0f, 0.0f, 0.0f };
-            static bool enableEdgeColor = false;
-            static Vector3 edgeColor = { 0.0f, 0.0f, 0.0f };
-            static float edgeDitectRange = 0.03f;
+        // アクティブエフェクトのリスト表示と管理
+        for (int i = 0; i < activeEffects.size(); i++) {
+            ImGui::PushID(i);
 
-            ImGui::SliderFloat("Dissolve Threshold", &threshold, 0.0f, 1.0f);
-            ImGui::ColorEdit3("Dissolve Mask Color", &maskColor.x);
-            ImGui::Checkbox("Enable Edge Color", &enableEdgeColor);
-            if (enableEdgeColor)
-            {
-                ImGui::ColorEdit3("Edge Color", &edgeColor.x);
-                ImGui::SliderFloat("Edge Range", &edgeDitectRange, 0.0f, 1.0f, "%.5f");
+            // エフェクト名の表示
+            ImGui::BulletText("%d: %s", i + 1, activeEffects[i].c_str());
+
+            ImGui::SameLine();
+
+            // エフェクトを上に移動するボタン
+            if (i > 0 && ImGui::Button("up")) {
+                std::swap(activeEffects[i], activeEffects[i - 1]);
             }
 
-            Dissolve::GetInstance()->SetThreshold(threshold);
-            Dissolve::GetInstance()->SetMaskColor(maskColor);
-            Dissolve::GetInstance()->SetEnableEdgeColor(enableEdgeColor);
-            Dissolve::GetInstance()->SetEdgeColor(edgeColor);
-            Dissolve::GetInstance()->SetEdgeDitectRange(edgeDitectRange);
+            ImGui::SameLine();
+
+            // エフェクトを下に移動するボタン
+            if (i < activeEffects.size() - 1 && ImGui::Button("dowm")) {
+                std::swap(activeEffects[i], activeEffects[i + 1]);
+            }
+
+            ImGui::SameLine();
+
+            // エフェクトを削除するボタン
+            if (ImGui::Button("X")) {
+                effectToRemove = i;
+            }
+
+            if (activeEffects[i] == "Dissolve")
+            {
+                static float threshold = 0.0f;
+                static Vector3 maskColor = { 0.0f, 0.0f, 0.0f };
+                static bool enableEdgeColor = false;
+                static Vector3 edgeColor = { 0.0f, 0.0f, 0.0f };
+                static float edgeDitectRange = 0.03f;
+
+                ImGui::SliderFloat("Dissolve Threshold", &threshold, 0.0f, 1.0f);
+                ImGui::ColorEdit3("Dissolve Mask Color", &maskColor.x);
+                ImGui::Checkbox("Enable Edge Color", &enableEdgeColor);
+                if (enableEdgeColor)
+                {
+                    ImGui::ColorEdit3("Edge Color", &edgeColor.x);
+                    ImGui::SliderFloat("Edge Range", &edgeDitectRange, 0.0f, 1.0f, "%.5f");
+                }
+
+                Dissolve::GetInstance()->SetThreshold(threshold);
+                Dissolve::GetInstance()->SetMaskColor(maskColor);
+                Dissolve::GetInstance()->SetEnableEdgeColor(enableEdgeColor);
+                Dissolve::GetInstance()->SetEdgeColor(edgeColor);
+                Dissolve::GetInstance()->SetEdgeDitectRange(edgeDitectRange);
+            }
+            else if (activeEffects[i] == "DepthBasedOutline")
+            {
+                //DepthBasedOutLine::GetInstance()->Set("default");
+            }
+
+            ImGui::PopID();
         }
-        else if (activeEffects[i] == "DepthBasedOutline")
-        {
-            //DepthBasedOutLine::GetInstance()->Set("default");
+
+        // 削除処理（forループの外で行う）
+        if (effectToRemove >= 0) {
+            activeEffects.erase(activeEffects.begin() + effectToRemove);
+            effectToRemove = -1;
         }
 
-        ImGui::PopID();
+        ImGui::End();
     }
-
-    // 削除処理（forループの外で行う）
-    if (effectToRemove >= 0) {
-        activeEffects.erase(activeEffects.begin() + effectToRemove);
-        effectToRemove = -1;
-    }
-
-    ImGui::End();
 #endif // _DEBUG
 
 }

--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -1,7 +1,7 @@
 [Window][Debug##Default]
-Pos=521,299
-Size=400,166
-Collapsed=0
+Pos=723,327
+Size=147,367
+Collapsed=1
 
 [Window][Dear ImGui Demo]
 Pos=266,47
@@ -54,9 +54,10 @@ Size=248,338
 Collapsed=0
 
 [Window][Engine]
-Pos=521,92
-Size=298,173
+Pos=985,372
+Size=295,348
 Collapsed=0
+DockId=0x0000000D,2
 
 [Window][CatmulRom]
 Pos=56,266
@@ -109,9 +110,10 @@ Size=425,717
 Collapsed=1
 
 [Window][LightGroup]
-Pos=268,29
-Size=249,648
-Collapsed=1
+Pos=985,372
+Size=295,348
+Collapsed=0
+DockId=0x0000000D,0
 
 [Window][Ring]
 Pos=255,18
@@ -132,14 +134,14 @@ Collapsed=0
 DockId=0x00000001,2
 
 [Window][DebugWindow]
-Pos=17,19
-Size=15,19
+Pos=1135,19
+Size=145,351
 Collapsed=0
-DockId=0x0000000B,1
+DockId=0x0000000C,0
 
 [Window][Debug]
-Pos=17,19
-Size=15,19
+Pos=985,19
+Size=148,351
 Collapsed=0
 DockId=0x0000000B,0
 
@@ -154,7 +156,7 @@ Size=612,159
 Collapsed=0
 
 [Window][WindowOverViewport_11111111]
-Pos=0,19
+Pos=0,0
 Size=32,32
 Collapsed=0
 
@@ -171,10 +173,10 @@ Collapsed=0
 DockId=0x0000000F,0
 
 [Window][Light Settings]
-Pos=17,37
+Pos=17,36
 Size=15,19
 Collapsed=0
-DockId=0x0000000C,0
+DockId=0x00000009,0
 
 [Window][TimeLine]
 Pos=0,17
@@ -195,10 +197,10 @@ Collapsed=0
 DockId=0x0000000A,1
 
 [Window][Post Effect Manager]
-Pos=17,37
+Pos=17,36
 Size=15,19
 Collapsed=0
-DockId=0x0000000C,1
+DockId=0x00000009,0
 
 [Window][TextureManager]
 Pos=14,250
@@ -206,8 +208,8 @@ Size=394,250
 Collapsed=0
 
 [Window][Dear ImGui ID Stack Tool]
-Pos=88,140
-Size=612,148
+Pos=64,122
+Size=612,147
 Collapsed=0
 
 [Window][Time Info]
@@ -219,6 +221,12 @@ Collapsed=0
 Pos=716,56
 Size=207,122
 Collapsed=0
+
+[Window][PostEffectManager]
+Pos=985,372
+Size=295,348
+Collapsed=0
+DockId=0x0000000D,1
 
 [Table][0xC9935533,3]
 Column 0  Weight=1.0000
@@ -271,15 +279,19 @@ Column 2  Width=56
 
 [Docking][Data]
 DockNode          ID=0x00000001 Pos=255,18 Size=325,299 Selected=0x52D7A061
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=X
-  DockNode        ID=0x00000005 Parent=0x08BD597D SizeRef=980,720 Split=Y
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
+  DockNode        ID=0x00000005 Parent=0x08BD597D SizeRef=983,720 Split=Y
     DockNode      ID=0x00000002 Parent=0x00000005 SizeRef=1280,463 Split=Y
       DockNode    ID=0x00000003 Parent=0x00000002 SizeRef=1042,412 Split=Y
         DockNode  ID=0x0000000E Parent=0x00000003 SizeRef=930,481 CentralNode=1 Selected=0x1FDCDEE6
         DockNode  ID=0x0000000F Parent=0x00000003 SizeRef=930,237 Selected=0x5879BBFD
       DockNode    ID=0x0000000A Parent=0x00000002 SizeRef=1042,306 Selected=0x42899545
     DockNode      ID=0x00000004 Parent=0x00000005 SizeRef=1280,255 Selected=0x4F89F0DC
-  DockNode        ID=0x00000006 Parent=0x08BD597D SizeRef=298,720 Split=Y Selected=0x4B6712B0
-    DockNode      ID=0x0000000B Parent=0x00000006 SizeRef=88,377 Selected=0x1E7E18E3
-    DockNode      ID=0x0000000C Parent=0x00000006 SizeRef=88,341 Selected=0xB5453E4F
+  DockNode        ID=0x00000006 Parent=0x08BD597D SizeRef=295,720 Split=Y Selected=0xB5453E4F
+    DockNode      ID=0x00000008 Parent=0x00000006 SizeRef=298,347 Split=Y Selected=0x4B6712B0
+      DockNode    ID=0x00000007 Parent=0x00000008 SizeRef=142,351 Split=X Selected=0x1E7E18E3
+        DockNode  ID=0x0000000B Parent=0x00000007 SizeRef=148,351 Selected=0x1E7E18E3
+        DockNode  ID=0x0000000C Parent=0x00000007 SizeRef=145,351 Selected=0x4B6712B0
+      DockNode    ID=0x0000000D Parent=0x00000008 SizeRef=142,348 Selected=0xAC437A35
+    DockNode      ID=0x00000009 Parent=0x00000006 SizeRef=298,352 Selected=0xB5453E4F
 


### PR DESCRIPTION
ImGuiデバッグマネージャーの統合とUI改善

`LightGroup.cpp`でのデバッグ用ウィンドウの開始と終了を`ImGuiDebugManager`を使用して行うように変更し、設定表示用のチェックボックスを追加しました。 `SampleFramework.cpp`の`RenderUI`関数内でも`ImGuiDebugManager`を使用し、ポストエフェクトマネージャーのウィンドウを整理しました。 `imgui.ini`ファイルでは、ウィンドウの位置、サイズ、ドッキング情報が更新され、`LightGroup`や`PostEffectManager`のウィンドウが新しい位置に配置されました。