### PR TITLE
ImGuiDebugManager::Begin メソッドの修正

### DIFF
--- a/Engine/Debug/ImGuiDebugManager.cpp
+++ b/Engine/Debug/ImGuiDebugManager.cpp
@@ -205,7 +205,7 @@ void ImGuiDebugManager::ShowDebugWindow()
 #endif // _DEBUG
 }
 
-bool ImGuiDebugManager::Begin(const std::string& _name/*, ImGuiWindowFlags _flags*/)
+bool ImGuiDebugManager::Begin(const std::string& _name)
 {
 #ifdef _DEBUG
     // 始めてのとき
@@ -221,7 +221,7 @@ bool ImGuiDebugManager::Begin(const std::string& _name/*, ImGuiWindowFlags _flag
         return false; // ウィンドウが非表示の場合は何もしない
     }
 
-    ImGui::Begin(_name.c_str(), &windowsVisibility_[_name], _flags);
+    ImGui::Begin(_name.c_str(), &windowsVisibility_[_name]);
 
 #endif // _DEBUG
     return true;

--- a/Engine/Debug/ImGuiDebugManager.h
+++ b/Engine/Debug/ImGuiDebugManager.h
@@ -26,7 +26,7 @@ public:
     /// <param name="_name">window名</param>
     /// <param name="_flags">ImGuiWindowFlags </param>
     /// <returns> ウィンドウが開始されたかどうか </returns>
-    bool Begin(const std::string& _name = "DebugWindow" /*,ImGuiWindowFlags _flags = ImGuiWindowFlags_None*/);
+    bool Begin(const std::string& _name = "DebugWindow");
 
     /// <summary>
     /// デバッグウィンドウを追加する


### PR DESCRIPTION
`ImGuiDebugManager::Begin` メソッドから `ImGuiWindowFlags` パラメータを削除しました。これに伴い、`ShowDebugWindow` メソッド内の呼び出しも更新され、ヘッダーファイル `ImGuiDebugManager.h` の宣言からも `_flags` パラメータが削除されています。