### PR TITLE
カメラのImGui周りを変更

### DIFF
--- a/Engine/Features/Camera/Camera/Camera.cpp
+++ b/Engine/Features/Camera/Camera/Camera.cpp
@@ -4,14 +4,12 @@
 #include <System/Input/Input.h>
 #include <Math/Vector/VectorFunction.h>
 #include <Math/Random/RandomGenerator.h>
-#ifdef _DEBUG
-#include <imgui.h>
-#endif // _DEBUG
+
+#include <Debug/ImGuiDebugManager.h>
 
 
 void Camera::Initialize(CameraType _cameraType, const Vector2& _winSize)
 {
-
     cameraType_ = _cameraType;
     winSize_ = _winSize;
     aspectRatio_ = winSize_.x / winSize_.y;
@@ -31,23 +29,9 @@ void Camera::Initialize(CameraType _cameraType, const Vector2& _winSize)
     gameTime_ = GameTime::GetInstance();
 }
 
-void Camera::Update(bool _showImGui)
+void Camera::Update()
 {
-#ifdef _DEBUG
-    if(_showImGui)
-    {
-        if (ImGui::BeginTabBar("camera"))
-        {
-            if (ImGui::BeginTabItem("camera"))
-            {
-                ImGui::DragFloat3("translate", &translate_.x, 0.01f);
-                ImGui::DragFloat3("rotate", &rotate_.x, 0.01f);
-                ImGui::EndTabItem();
-            }
-            ImGui::EndTabBar();
-        }
-    }
-#endif // _DEBUG
+
 
     if (shaking_)
     {
@@ -148,6 +132,21 @@ void Camera::ShakeParametaerSettingFromImGui()
 void Camera::QueueCommand(ID3D12GraphicsCommandList* _cmdList, UINT _index) const
 {
     _cmdList->SetGraphicsRootConstantBufferView(_index, resource_->GetGPUVirtualAddress());
+}
+
+void Camera::ImGui()
+{
+#ifdef _DEBUG
+    if (ImGuiDebugManager::GetInstance()->Begin("Camera"))
+    {
+        ImGui::DragFloat3("translate", &translate_.x, 0.01f);
+        ImGui::DragFloat3("rotate", &rotate_.x, 0.01f);
+
+        ShakeParametaerSettingFromImGui();
+
+        ImGui::End();
+    }
+#endif // _DEBUG
 }
 
 void Camera::UpdateShake()

--- a/Engine/Features/Camera/Camera/Camera.h
+++ b/Engine/Features/Camera/Camera/Camera.h
@@ -21,7 +21,7 @@ public:
     ~Camera() = default;
 
     void Initialize(CameraType _cameraType = CameraType::Perspective, const Vector2& _winSize = { 1280.0f, 720.0f });
-    void Update(bool _showImGui = true);
+    void Update();
     void Draw();
 
     ID3D12Resource* GetResource()const { return resource_.Get(); }
@@ -72,6 +72,10 @@ public:
 
     // 透視投影か正射影投影か
     CameraType cameraType_ = CameraType::Perspective;
+
+    void ImGui();
+private:
+
 
 private:
     // ortho用


### PR DESCRIPTION
関数として独立させpublicにした

カメラ更新の修正

`Camera.cpp` に `Debug/ImGuiDebugManager.h` を追加し、デバッグ用の ImGui 機能を実装しました。`Camera::Update` メソッドから `_showImGui` 引数を削除し、カメラの揺れを更新する処理を追加しました。また、`Camera::ImGui` メソッドを新たに追加し、カメラの位置や回転を ImGui で調整できるようにしました。

`Camera.h` でも同様に、`Update` メソッドの引数を削除し、`ImGui` メソッドを追加しました。これにより、カメラのデバッグ情報表示機能が強化されました。