### PR TITLE
フィルタービルダーの改善とメソッドの統一

### DIFF
--- a/Engine/Utility/FileDialog/FileDialog.h
+++ b/Engine/Utility/FileDialog/FileDialog.h
@@ -31,32 +31,34 @@ public:
     };
 
 public:
-
+    // 単体フィルター文字列取得（Windows API直接使用時）
     static std::string GetFilterString(FilterType _filterType);
 
+    // ビルダーにフィルターを追加
     FileFilterBuilder& Add(FilterType _filterType);
 
+    // カスタムフィルターを追加
     FileFilterBuilder& AddCustom(const std::string& _description, const std::string& _extension);
 
+    // 個別拡張子として追加
     FileFilterBuilder& AddSeparateExtensions(FilterType _filterType);
 
+    // 最終的なフィルター文字列を構築
     std::string Build();
 
+    // ビルダーをリセット
+    FileFilterBuilder& Reset();
+
 private:
-
     void AddImageExtensions();
-
     void AddAudioExtensions();
-
     void AddDataExtensions();
-
-    void AppendString(const std::string& _str);
-    void AppendNull();
+    void AppendFilter(const std::string& _description, const std::string& _extension);
 
     static std::map<FilterType, std::pair<std::string, std::string>> filterMap;
     std::vector<char> combinatedFilter_;
-
 };
+
 
 
 


### PR DESCRIPTION
`FileFilterBuilder` クラスの `GetFilterString` メソッドを改善し、日本語のデフォルトフィルター名を追加しました。`Add` と `AddCustom` メソッドの処理を簡素化し、`AppendFilter` メソッドを導入してフィルター追加処理を統一しました。`Build` メソッドの空フィルター処理を改善し、`Reset` メソッドを追加しました。拡張子追加メソッドのフィルター名を一貫性のある形式に変更し、`FileDialog` クラスのインターフェースを更新しました。