### PR TITLE
StringUtilsにGetAfterLastとGetBeforeLastを追加

### DIFF
--- a/Engine/Utility/StringUtils/StringUitls.cpp
+++ b/Engine/Utility/StringUtils/StringUitls.cpp
@@ -20,6 +20,26 @@ std::string StringUtils::GetAfter(const std::string& _str, const std::string& _d
     return  ""; // デリミタが見つからない場合は空文字列を返す
 }
 
+std::string StringUtils::GetAfterLast(const std::string& _str, char _delimiter)
+{
+    size_t pos = _str.find_last_of(_delimiter);
+    if (pos != std::string::npos && pos + 1 < _str.size())
+    {
+        return _str.substr(pos + 1);
+    }
+    return ""; // デリミタが見つからない場合は空文字列を返す
+}
+
+std::string StringUtils::GetAfterLast(const std::string& _str, const std::string& _delimiter)
+{
+    size_t pos = _str.find_last_of(_delimiter);
+    if (pos != std::string::npos && pos + _delimiter.size() < _str.size())
+    {
+        return _str.substr(pos + _delimiter.size());
+    }
+    return ""; // デリミタが見つからない場合は空文字列を返す
+}
+
 std::string StringUtils::GetBefore(const std::string& _str, char _delimiter)
 {
     size_t pos = _str.find(_delimiter);
@@ -38,6 +58,26 @@ std::string StringUtils::GetBefore(const std::string& _str, const std::string& _
         return _str.substr(0, pos);
     }
     return  ""; // デリミタが見つからない場合は空文字列を返す
+}
+
+std::string StringUtils::GetBeforeLast(const std::string& _str, char _delimiter)
+{
+    size_t pos = _str.find_last_of(_delimiter);
+    if (pos != std::string::npos)
+    {
+        return _str.substr(0, pos);
+    }
+    return ""; // デリミタが見つからない場合は空文字列を返す
+}
+
+std::string StringUtils::GetBeforeLast(const std::string& _str, const std::string& _delimiter)
+{
+    size_t pos = _str.find_last_of(_delimiter);
+    if (pos != std::string::npos)
+    {
+        return _str.substr(0, pos);
+    }
+    return ""; // デリミタが見つからない場合は空文字列を返す
 }
 
 std::string StringUtils::GetExtension(const std::string& _str)

--- a/Engine/Utility/StringUtils/StringUitls.h
+++ b/Engine/Utility/StringUtils/StringUitls.h
@@ -21,6 +21,22 @@ namespace StringUtils
     std::string GetAfter(const std::string& _str, const std::string& _delimiter);
 
     /// <summary>
+    /// 指定文字列の最後の出現位置以降の文字列を取得
+    /// </summary>
+    /// <param name="_str">操作を行う文字列</param>
+    /// <param name="_delimiter">対象の文字</param>
+    /// <returns>操作後の文字列</returns>
+    std::string GetAfterLast(const std::string& _str, char _delimiter);
+
+    /// <summary>
+    /// 指定文字列の最後の出現位置以降の文字列を取得
+    /// </summary>
+    /// <param name="_str">操作を行う文字列</param>
+    /// <param name="_delimiter">対象の文字列</param>
+    /// <returns>操作後の文字列</returns>
+    std::string GetAfterLast(const std::string& _str, const std::string& _delimiter);
+
+    /// <summary>
     /// 指定文字以前の文字列を取得
     /// </summary>
     /// <param name="_str">操作を行う文字列</param>
@@ -36,6 +52,22 @@ namespace StringUtils
     /// <param name="_delimiter">対象の文字列</param>
     /// <returns>操作後の文字列</returns>
     std::string GetBefore(const std::string& _str, const std::string& _delimiter);
+
+    /// <summary>
+    /// 指定文字列の最後の出現位置以前の文字列を取得
+    /// </summary>
+    /// <param name="_str"> 操作を行う文字列</param>
+    /// <param name="_delimiter">対象の文字</param>
+    /// <returns>操作後の文字列</returns>
+    std::string GetBeforeLast(const std::string& _str, char _delimiter);
+
+    /// <summary>
+    /// 指定文字列の最後の出現位置以前の文字列を取得
+    /// </summary>
+    /// <param name="_str"> 操作を行う文字列</param>
+    /// <param name="_delimiter">対象の文字列</param>
+    /// <returns>操作後の文字列</returns>
+    std::string GetBeforeLast(const std::string& _str, const std::string& _delimiter);
 
     /// <summary>
     /// 文字列の拡張子を取得


### PR DESCRIPTION
StringUtils.cppに新しい関数`GetAfterLast`と`GetBeforeLast`を追加しました。これらの関数は、指定されたデリミタの最後の出現位置以降または以前の文字列を取得します。デリミタが見つからない場合には空文字列を返すように実装されています。

また、StringUtils.hにこれらの関数に対応するドキュメンテーションコメントを追加し、関数の目的や引数、戻り値についての説明を明確にしました。