### PR TITLE
デバッグウィンドウ機能の改善と新メソッド追加

### DIFF
--- a/Engine/Debug/ImGuiDebugManager.h
+++ b/Engine/Debug/ImGuiDebugManager.h
@@ -57,6 +57,11 @@ private:
 
     void MenuBar();
 
+    void SelectItemWindow();
+
+    void SelectedItemWindow();
+
+    void TabFlagsWindow();
 
 private:
 #ifdef _DEBUG


### PR DESCRIPTION
`ImGuiDebugManager::Initialize()` に新しいメンバー変数 `isAllWindowHidden_` を追加し、デバッグウィンドウの表示状態を管理するロジックを実装しました。従来の表示コードを削除し、`SelectItemWindow`、`SelectedItemWindow`、`TabFlagsWindow` の新メソッドを追加しました。

`ImGuiDebugManager::MenuBar()` では、ID スタックツールウィンドウの表示制御を追加しました。ヘッダーファイル `ImGuiDebugManager.h` には新メソッドが `public` セクションに追加され、クラスのインターフェースが拡張されました。