### PR TITLE
UIBase.hにGetAnchorメソッドを追加

### DIFF
--- a/Engine/Features/UI/UIBase.h
+++ b/Engine/Features/UI/UIBase.h
@@ -39,6 +39,7 @@ public:
     void SetRotate(float _rotate) { rotate_ = _rotate; }
     float GetRotate() const { return rotate_; }
     void SetAnchor(const Vector2& _anchor) { anchor_ = _anchor; };
+    const Vector2& GetAnchor() const { return anchor_; }
 
     void SetUVTranslate(const Vector2& _uvTranslate) { sprite_->uvTranslate_ = _uvTranslate; }
     void SetUVScale(const Vector2& _uvScale) { sprite_->uvScale_ = _uvScale; }

--- a/Engine/Utility/StringUtils/StringUitls.cpp
+++ b/Engine/Utility/StringUtils/StringUitls.cpp
@@ -32,7 +32,7 @@ std::string StringUtils::GetAfterLast(const std::string& _str, char _delimiter)
 
 std::string StringUtils::GetAfterLast(const std::string& _str, const std::string& _delimiter)
 {
-    size_t pos = _str.find_last_of(_delimiter);
+    size_t pos = _str.rfind(_delimiter);
     if (pos != std::string::npos && pos + _delimiter.size() < _str.size())
     {
         return _str.substr(pos + _delimiter.size());
@@ -72,7 +72,7 @@ std::string StringUtils::GetBeforeLast(const std::string& _str, char _delimiter)
 
 std::string StringUtils::GetBeforeLast(const std::string& _str, const std::string& _delimiter)
 {
-    size_t pos = _str.find_last_of(_delimiter);
+    size_t pos = _str.rfind(_delimiter);
     if (pos != std::string::npos)
     {
         return _str.substr(0, pos);


### PR DESCRIPTION
UIBase.h では、`GetAnchor` メソッドを追加し、`anchor_` メンバー変数の値を取得できるようにしました。

StringUtils.cpp では、`GetAfterLast` および `GetBeforeLast` メソッドの実装を変更し、`find_last_of` メソッドを `rfind` メソッドに置き換えました。これにより、指定されたデリミタの最後の出現位置をより効率的に取得できるようになりました。