### PR TITLE
lineDrawerに常時描画機能を実装

### DIFF
--- a/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.cpp
@@ -507,6 +507,7 @@ void PSOManager::CreateDefaultPSOs()
     CreatePSOForModel(PSOFlags::ForAlphaModel());
     CreatePSOForSprite(PSOFlags::ForSprite());
     CreatePSOForLineDrawer(PSOFlags::ForLineDrawer());
+    CreatePSOForLineDrawer(PSOFlags::ForLineDrawerAlways());
     CreatePSOForParticle(PSOFlags::ForAddBlendParticle());
 
     CreatePSOForText();
@@ -1926,6 +1927,13 @@ D3D12_DEPTH_STENCIL_DESC PSOManager::GetDepthStencilDesc(PSOFlags _flag)
         depthStencilDesc.DepthEnable = true;
         depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
         depthStencilDesc.DepthFunc = D3D12_COMPARISON_FUNC_GREATER;
+        return depthStencilDesc;
+    }
+    else if (depthMode == PSOFlags::DepthMode::Comb_mZero_fAlways)
+    {
+        depthStencilDesc.DepthEnable = true;
+        depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
+        depthStencilDesc.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
         return depthStencilDesc;
     }
 

--- a/Engine/Core/DXCommon/PSOManager/PSOManager.h
+++ b/Engine/Core/DXCommon/PSOManager/PSOManager.h
@@ -58,6 +58,8 @@ struct PSOFlags
         Comb_mZero_fLessEqual = Enable | MaskZero | FuncLessEqual,
         // 書き込まない 奥を描画する 壁の向こうのシルエットとか
         Comb_mAll_fGreater = Enable | MaskAll | FuncGreater,
+
+        Comb_mZero_fAlways = Enable | MaskZero | FuncAlways, // 書き込まない 常に描画する
     };
 
     static constexpr uint64_t TypeShift = 0;          // Typeのビットシフト
@@ -151,6 +153,9 @@ struct PSOFlags
     }
     static constexpr PSOFlags ForLineDrawer() {
         return Combine(Type::LineDrawer, BlendMode::Normal, CullMode::None, DepthMode::Comb_mZero_fLessEqual);
+    }
+    static constexpr PSOFlags ForLineDrawerAlways() {
+        return Combine(Type::LineDrawer, BlendMode::Normal, CullMode::None, DepthMode::Comb_mZero_fAlways);
     }
     static constexpr PSOFlags ForAddBlendParticle() {
         return Combine(Type::Particle, BlendMode::Add, CullMode::None, DepthMode::Comb_mZero_fLessEqual);

--- a/Engine/Features/LineDrawer/LineDrawer.h
+++ b/Engine/Features/LineDrawer/LineDrawer.h
@@ -21,25 +21,26 @@ public:
     void SetCameraPtr(const Camera* _cameraPtr) { cameraFor3dptr_ = _cameraPtr; }
     void SetCameraPtr2D(const Camera* _cameraPtr) { cameraFor2dptr_ = _cameraPtr; }
     void SetColor(const Vector4& _color) { color_ = _color; }
-    void RegisterPoint(const Vector3& _start, const Vector3& _end);
-    void RegisterPoint(const Vector3& _start, const Vector3& _end,const Vector4& _color);
+    void RegisterPoint(const Vector3& _start, const Vector3& _end, bool _frontDraw = false);
+    void RegisterPoint(const Vector3& _start, const Vector3& _end,const Vector4& _color, bool _frontDraw = false);
     void RegisterPoint(const Vector2& _start, const Vector2& _end);
     void RegisterPoint(const Vector2& _start, const Vector2& _end, const Vector4& _color);
     void Draw();
 
-    void DrawOBB(const Matrix4x4& _affineMat);
-    void DrawOBB(const Matrix4x4& _affineMat, const Vector4& _color);
-    void DrawOBB(const std::array <Vector3, 8>& _vertices);
-    void DrawOBB(const std::array <Vector3, 8>& _vertices, const Vector4& _color);
+    void DrawOBB(const Matrix4x4& _affineMat, bool _frontDraw = false);
+    void DrawOBB(const Matrix4x4& _affineMat, const Vector4& _color, bool _frontDraw = false);
+    void DrawOBB(const std::array <Vector3, 8>& _vertices, bool _frontDraw = false);
+    void DrawOBB(const std::array <Vector3, 8>& _vertices, const Vector4& _color, bool _frontDraw = false);
 
-    void DrawSphere(const Matrix4x4& _affineMat);
-    void DrawSphere(const Matrix4x4& _affineMat, const Vector4& _color);
-    void DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal);
-    void DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal, const Vector4& _color);
+    void DrawSphere(const Matrix4x4& _affineMat, bool _frontDraw = false);
+    void DrawSphere(const Matrix4x4& _affineMat, const Vector4& _color, bool _frontDraw = false);
+    void DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal, bool _frontDraw = false);
+    void DrawCircle(const Vector3& _center, float _radius, const float _segmentCount, const Vector3& _normal, const Vector4& _color, bool _frontDraw = false);
 
 private:
     void Draw3Dlines();
     void Draw2Dlines();
+    void Draw3DlinesAlways();
 
     void TransferData();
 
@@ -47,12 +48,16 @@ private:
 
     const uint32_t kMaxNum = 4096u * 24u;
     uint32_t indexFor3d_ = 0u;
+    uint32_t indexFor3dAlways_ = 0u;
     uint32_t indexFor2d_ = 0u;
     Vector4 color_ = { 0,0,0,1 };
     const Camera* cameraFor3dptr_=nullptr;
     const Camera* cameraFor2dptr_ = nullptr;
     ID3D12RootSignature* rootSignature_ = nullptr;
     ID3D12PipelineState* graphicsPipelineState_ = nullptr;
+
+    // 常時描画のためのPipelineStateObject
+    ID3D12PipelineState* graphicsPipelineStateForAlways_ = nullptr;
 
     struct ConstantBufferData
     {
@@ -78,6 +83,10 @@ private:
     Microsoft::WRL::ComPtr<ID3D12Resource>      vertexResourceFor2D_ = nullptr;
     D3D12_VERTEX_BUFFER_VIEW                    vertexBufferViewFor2D_ = {};
 
+    PointData* vConstMapFor3DAlways_ = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12Resource>      vertexResourceFor3DAlways_ = nullptr;
+    D3D12_VERTEX_BUFFER_VIEW                    vertexBufferViewFor3DAlways_ = {};
+
 
     void SetVerties();
 
@@ -88,6 +97,8 @@ private:
     const float kDivision = 8;
     std::vector <Vector3> sphereVertices_;
     std::vector <uint32_t> sphereIndices_;
+
+private:
 
     LineDrawer() = default;
     ~LineDrawer() = default;

--- a/Engine/Features/Model/Animation/Controller/AnimationController.cpp
+++ b/Engine/Features/Model/Animation/Controller/AnimationController.cpp
@@ -138,3 +138,13 @@ bool AnimationController::IsAnimationPlaying() const
 {
     return currentAnimation_ && currentAnimation_->IsPlaying();
 }
+
+void AnimationController::ImGui()
+{
+#ifdef _DEBUG
+
+    skeleton_.ImGui();
+
+
+#endif // _DEBUG
+}

--- a/Engine/Features/Model/Animation/Controller/AnimationController.h
+++ b/Engine/Features/Model/Animation/Controller/AnimationController.h
@@ -51,6 +51,9 @@ public:
     // アニメーションが再生中かどうか
     bool IsAnimationPlaying() const;
 
+
+    void ImGui();
+    
 private:
 
     Model* model_ = nullptr;

--- a/Engine/Features/Model/Animation/Joint/Joint.cpp
+++ b/Engine/Features/Model/Animation/Joint/Joint.cpp
@@ -28,13 +28,14 @@ void Joint::Draw(const Matrix4x4& _wMat, std::vector <Joint>& _joints)
     Matrix4x4 wMat = SkeletonSpcaceMatrix_ * _wMat;
     static Matrix4x4 sMat = MakeScaleMatrix({ 0.1f,0.1f ,0.1f });
 
-    LineDrawer::GetInstance()->DrawOBB(sMat * wMat);
+    Vector4 color = openTree_ ? Vector4{ 1,0,0,1 } : Vector4{ 1,1,1,1 };
 
+    LineDrawer::GetInstance()->DrawOBB(sMat * wMat, color, true);
     Vector3 pos = Transform({ 0,0,0 }, wMat);
     for (int32_t childIndex : children_)
     {
         Vector3 childPos = Transform({ 0,0,0 }, _joints[childIndex].SkeletonSpcaceMatrix_ * _wMat);
-        LineDrawer::GetInstance()->RegisterPoint(pos, childPos);
+        LineDrawer::GetInstance()->RegisterPoint(pos, childPos, color, true);
     }
 }
 
@@ -58,4 +59,39 @@ int32_t Joint::CreateJoint(const Node& _node, const std::optional<int32_t>& _par
 
 
     return joint.index_;
+}
+
+void Joint::ImGui(std::unordered_map<std::string, int32_t>& _map, int32_t indent)
+{
+#ifdef _DEBUG
+
+    if (_map.contains(name_))
+        return;
+
+    _map[name_] = index_;
+
+    ImGui::PushID(this);
+    std::string label = std::string(indent, '\t') + name_;
+
+    openTree_ = false;
+
+    if (ImGui::TreeNode(label.c_str()))
+    {
+        ImGui::Text("Index : %d", index_);
+        ImGui::Text("Children Count : %d", static_cast<int32_t>(children_.size()));
+        ImGui::Text("Transform : ");
+        ImGui::Text("  Scale : %.2f, %.2f, %.2f", transform_.scale.x, transform_.scale.y, transform_.scale.z);
+        ImGui::Text("  Rotation : %.2f, %.2f, %.2f", transform_.rotation.x, transform_.rotation.y, transform_.rotation.z);
+        ImGui::Text("  Translate : %.2f, %.2f, %.2f", transform_.translate.x, transform_.translate.y, transform_.translate.z);
+
+        openTree_ = true;
+
+        ImGui::TreePop();
+    }
+
+    ImGui::PopID();
+
+    indent += 2;
+
+#endif // _DEBUG
 }

--- a/Engine/Features/Model/Animation/Joint/Joint.h
+++ b/Engine/Features/Model/Animation/Joint/Joint.h
@@ -26,6 +26,12 @@ public:
     QuaternionTransform GetTransform() const { return transform_; }
     QuaternionTransform GetIdleTransform() const { return idleTransform_; }
 
+    const std::vector<int32_t>& GetChildren() const { return children_; }
+
+#ifdef _DEBUG
+    void ImGui(std::unordered_map<std::string, int32_t>& _map, int32_t indent);
+#endif // _DEBUG
+
     std::string name_ = {};
     int32_t index_ = 0;
 private:
@@ -37,5 +43,5 @@ private:
 
     QuaternionTransform idleTransform_ = {};
 
-
+    bool openTree_ = false;
 };

--- a/Engine/Features/Model/Animation/Skeleton/Skeleton.cpp
+++ b/Engine/Features/Model/Animation/Skeleton/Skeleton.cpp
@@ -1,10 +1,6 @@
 #include <Features/Model/Animation/Skeleton/Skeleton.h>
 #include <Features/Model/Animation/Node/Node.h>
 
-void Skeleton::Initialize()
-{
-}
-
 void Skeleton::Update()
 {
     for (Joint& joint : joints_)
@@ -28,4 +24,36 @@ void Skeleton::CreateSkeleton(const Node& _node)
     {
         jointMap_.emplace(joint.name_, joint.index_);
     }
+}
+
+void Skeleton::ImGui()
+{
+#ifdef _DEBUG
+
+    ImGui::SeparatorText("Skeleton");
+    ImGui::Text("Root Joint : %s", joints_[rootIndex_].name_.c_str());
+    ImGui::Text("Joint Count : %d", static_cast<int32_t>(joints_.size()));
+
+    debugJointMap_.clear();
+
+    Joint& joint = joints_[rootIndex_];
+
+    Show(joint, 0);
+
+#endif // _DEBUG
+}
+
+void Skeleton::Show(Joint& _joint, uint32_t _indent)
+{
+
+    _joint.ImGui(debugJointMap_, _indent);
+
+    auto children = _joint.GetChildren();
+    for (int32_t childIndex : children)
+    {
+        if (debugJointMap_.contains(joints_[childIndex].name_))
+            continue;
+        Show(joints_[childIndex], _indent + 1);
+    }
+
 }

--- a/Engine/Features/Model/Animation/Skeleton/Skeleton.h
+++ b/Engine/Features/Model/Animation/Skeleton/Skeleton.h
@@ -13,7 +13,6 @@ public:
     Skeleton() = default;
     ~Skeleton() = default;
 
-    void Initialize();
     void Update();
     void Draw(const Matrix4x4& _wMat);
 
@@ -21,9 +20,19 @@ public:
     std::vector<Joint>& GetJoints() { return joints_; }
     std::map<std::string, int32_t>& GetJointMap() { return jointMap_; }
     Matrix4x4 GetSkeletonSpaceMatrix(uint32_t _index = 0)const { return joints_[_index].GetSkeletonSpaceMatrix(); }
+
+
+#ifdef _DEBUG
+    std::unordered_map<std::string, int32_t> debugJointMap_ = {};
+    void ImGui();
+
+    void Show(Joint& _joint, uint32_t _indent);
+#endif // _DEBUG
+
 private:
     int32_t rootIndex_ = 0;
     std::map<std::string, int32_t> jointMap_ = {};
     std::vector<Joint> joints_ = {};
+
 
 };

--- a/Engine/Features/Model/ObjectModel.cpp
+++ b/Engine/Features/Model/ObjectModel.cpp
@@ -201,6 +201,13 @@ void ObjectModel::ImGui()
     {
         SetModel(filePathBuffer_);
     }
+
+    if(animationController_)
+    {
+        if(ImGui::CollapsingHeader("Skeleton"))
+            animationController_->ImGui();
+    }
+
     ImGui::PopID();
 
 #endif // _DEBUG

--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -155,7 +155,7 @@ Collapsed=0
 
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=1280,701
+Size=32,32
 Collapsed=0
 
 [Window][Timeline]
@@ -226,13 +226,18 @@ Size=295,348
 Collapsed=0
 
 [Window][Select Item]
-Pos=14,39
+Pos=41,31
 Size=221,137
 Collapsed=0
 
 [Window][Selected Items]
-Pos=852,283
-Size=379,294
+Pos=769,29
+Size=707,618
+Collapsed=0
+
+[Window][Tab Flags]
+Pos=60,60
+Size=114,54
 Collapsed=0
 
 [Table][0xC9935533,3]
@@ -286,7 +291,7 @@ Column 2  Width=56
 
 [Docking][Data]
 DockNode          ID=0x00000001 Pos=255,18 Size=325,299 Selected=0x52D7A061
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=X
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=X
   DockNode        ID=0x00000005 Parent=0x08BD597D SizeRef=983,720 Split=Y
     DockNode      ID=0x00000002 Parent=0x00000005 SizeRef=1280,463 Split=Y
       DockNode    ID=0x00000003 Parent=0x00000002 SizeRef=1042,412 Split=Y


### PR DESCRIPTION
skeleton情報をimguiウィンドウで見れるように
選択jointの色を変えわかりやすく。

常時描画機能の追加とデバッグ用UIの強化

PSOManagerに常時描画用のPSO生成機能を追加し、深度ステンシル設定を更新しました。LineDrawerでは、前面描画フラグを受け取るようにRegisterPoint関数を変更し、常時描画用のライン描画機能を実装しました。また、AnimationController、Joint、Skeletonにデバッグ用のImGui関数を追加し、アニメーションやジョイント、スケルトンの情報を表示できるようにしました。さらに、ObjectModelにスケルトン情報表示機能を追加し、imgui.iniのウィンドウ設定も更新しました。