### PR TITLE
animationControler追加に伴う不具合の修正

### DIFF
--- a/Engine/Features/Model/Animation/Controller/AnimationController.cpp
+++ b/Engine/Features/Model/Animation/Controller/AnimationController.cpp
@@ -10,7 +10,7 @@ AnimationController::AnimationController(Model* _model) :
 {
 }
 
-void AnimationController::Initialize()
+void AnimationController::Initialize(ID3D12PipelineState* _computePipeline, ID3D12RootSignature* _rootSignature)
 {
     if (!model_)
         return;
@@ -31,7 +31,7 @@ void AnimationController::Initialize()
 
     margedMesh_->SetSkinnedVertexBufferView(SkinningCS::CreateOutputVertexResource(vertexCount));
 
-    skinningCS_ = std::make_unique<SkinningCS>();
+    skinningCS_ = std::make_unique<SkinningCS>(_computePipeline, _rootSignature);
 
     skinningCS_->CreateSRVForInputVertexResource(margedMesh_->GetVertexResource(), vertexCount);
     skinningCS_->CreateSRVForInfluenceResource(skinCluster_.GetInfluenceResource(), vertexCount);

--- a/Engine/Features/Model/Animation/Controller/AnimationController.h
+++ b/Engine/Features/Model/Animation/Controller/AnimationController.h
@@ -21,7 +21,7 @@ public:
     ~AnimationController() = default;
 
     // 初期化
-    void Initialize();
+    void Initialize(ID3D12PipelineState* _computePipeline, ID3D12RootSignature* _rootSignature);
 
     // 更新
     void Update(float _deltaTime);

--- a/Engine/Features/Model/Animation/Skeleton/Skeleton.cpp
+++ b/Engine/Features/Model/Animation/Skeleton/Skeleton.cpp
@@ -26,9 +26,9 @@ void Skeleton::CreateSkeleton(const Node& _node)
     }
 }
 
+#ifdef _DEBUG
 void Skeleton::ImGui()
 {
-#ifdef _DEBUG
 
     ImGui::SeparatorText("Skeleton");
     ImGui::Text("Root Joint : %s", joints_[rootIndex_].name_.c_str());
@@ -40,7 +40,6 @@ void Skeleton::ImGui()
 
     Show(joint, 0);
 
-#endif // _DEBUG
 }
 
 void Skeleton::Show(Joint& _joint, uint32_t _indent)
@@ -57,3 +56,4 @@ void Skeleton::Show(Joint& _joint, uint32_t _indent)
     }
 
 }
+#endif // _DEBUG

--- a/Engine/Features/Model/Animation/SkinningCS.h
+++ b/Engine/Features/Model/Animation/SkinningCS.h
@@ -16,10 +16,9 @@ class SRVManager;
 class SkinningCS
 {
 public:
-    SkinningCS();
+    SkinningCS(ID3D12PipelineState* _computePipeline, ID3D12RootSignature* _rootSignature);
     ~SkinningCS();
 
-    void Initialize();
     void Execute();
 
     uint32_t CreateSRVForInputVertexResource(ID3D12Resource* _resource, uint32_t _vertexNum);
@@ -40,11 +39,8 @@ public:
 private:
     void CreateInfoResource(uint32_t _vertexNum);
 
-    void CreateComputePipeline();
-
-    static bool isCreated_;
-    static Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipeline_;
-    static Microsoft::WRL::ComPtr<ID3D12RootSignature> rootSignature_;
+    ID3D12PipelineState* computePipeline_;
+    ID3D12RootSignature* rootSignature_;
 
     DXCommon* dxCommon_;
     ID3D12GraphicsCommandList* commandList_;

--- a/Engine/Features/Model/Manager/ModelManager.cpp
+++ b/Engine/Features/Model/Manager/ModelManager.cpp
@@ -3,6 +3,7 @@
 #include <Core/DXCommon/PSOManager/PSOManager.h>
 #include <Core/DXCommon/DXCommon.h>
 #include <cassert>
+#include <LevelEditorLoader.cpp>
 
 ModelManager* ModelManager::GetInstance()
 {
@@ -33,7 +34,7 @@ void ModelManager::Initialize()
     assert(psoAlpha.has_value() && psoAlpha != nullptr);
     graphicsPipelineStateForAlpha_ = psoAlpha.value();
 
-
+    CreateComputePipeline();
  }
 
 void ModelManager::PreDrawForObjectModel() const
@@ -77,4 +78,102 @@ Model* ModelManager::Create(const std::string& _name)
 
     models_[name] = std::make_unique<Model>();
     return models_[name].get();
+}
+
+void ModelManager::CreateComputePipeline()
+{
+    HRESULT hr = S_FALSE;
+
+
+    D3D12_ROOT_SIGNATURE_DESC descriptionRootSignature{};
+    descriptionRootSignature.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+    D3D12_DESCRIPTOR_RANGE descriptorRanges[4] = {};
+    // gMatrixPalette
+    descriptorRanges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    descriptorRanges[0].NumDescriptors = 1;
+    descriptorRanges[0].BaseShaderRegister = 0;
+    descriptorRanges[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    // inputVertex
+    descriptorRanges[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    descriptorRanges[1].NumDescriptors = 1;
+    descriptorRanges[1].BaseShaderRegister = 1;
+    descriptorRanges[1].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    // gInfluence
+    descriptorRanges[2].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    descriptorRanges[2].NumDescriptors = 1;
+    descriptorRanges[2].BaseShaderRegister = 2;
+    descriptorRanges[2].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    // outputVertex
+    descriptorRanges[3].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
+    descriptorRanges[3].NumDescriptors = 1;
+    descriptorRanges[3].BaseShaderRegister = 0;
+    descriptorRanges[3].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+
+    D3D12_ROOT_PARAMETER rootParameters[5] = {};
+
+    // gMatrixPalette
+    rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    rootParameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[0].DescriptorTable.pDescriptorRanges = &descriptorRanges[0];
+    rootParameters[0].DescriptorTable.NumDescriptorRanges = 1;
+
+    // inputVertex
+    rootParameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[1].DescriptorTable.pDescriptorRanges = &descriptorRanges[1];
+    rootParameters[1].DescriptorTable.NumDescriptorRanges = 1;
+
+    // gInfluence
+    rootParameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[2].DescriptorTable.pDescriptorRanges = &descriptorRanges[2];
+    rootParameters[2].DescriptorTable.NumDescriptorRanges = 1;
+
+    // outputVertex
+    rootParameters[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    rootParameters[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[3].DescriptorTable.pDescriptorRanges = &descriptorRanges[3];
+    rootParameters[3].DescriptorTable.NumDescriptorRanges = 1;
+
+    // skinnedInformation
+    rootParameters[4].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+    rootParameters[4].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[4].Descriptor.ShaderRegister = 0;
+
+
+    descriptionRootSignature.pParameters = rootParameters;
+    descriptionRootSignature.NumParameters = _countof(rootParameters);
+
+
+    //シリアライズしてバイナリする
+    Microsoft::WRL::ComPtr<ID3DBlob> signatureBlob = nullptr;
+    Microsoft::WRL::ComPtr<ID3DBlob> errorBlob = nullptr;
+    hr = D3D12SerializeRootSignature(&descriptionRootSignature, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, &errorBlob);
+    if (FAILED(hr))
+    {
+        Debug::Log(reinterpret_cast<char*>(errorBlob->GetBufferPointer()));
+        assert(false);
+    }
+    hr = DXCommon::GetInstance()->GetDevice()->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize(), IID_PPV_ARGS(&rootSignatureForCompute_));
+    assert(SUCCEEDED(hr));
+
+
+    // ComputeShaderの設定
+    Microsoft::WRL::ComPtr<IDxcBlob> computeShaderBlob = nullptr;
+    // ComputeShaderのコンパイル
+    computeShaderBlob = PSOManager::GetInstance()->ComplieShader(L"Skinning.CS.hlsl", L"cs_6_0");
+    assert(computeShaderBlob != nullptr);
+
+    D3D12_COMPUTE_PIPELINE_STATE_DESC computePsoDesc = {};
+    computePsoDesc.pRootSignature = rootSignatureForCompute_.Get();
+    computePsoDesc.CS = { computeShaderBlob->GetBufferPointer(), computeShaderBlob->GetBufferSize() };
+
+    hr = DXCommon::GetInstance()->GetDevice()->CreateComputePipelineState(&computePsoDesc, IID_PPV_ARGS(&computePipeline_));
+    assert(SUCCEEDED(hr));
+
 }

--- a/Engine/Features/Model/Manager/ModelManager.h
+++ b/Engine/Features/Model/Manager/ModelManager.h
@@ -20,9 +20,14 @@ public:
     void PreDrawForObjectModel() const;
     void PreDrawForAlphaObjectModel() const;
 
+    ID3D12PipelineState* GetComputePipeline() const { return computePipeline_.Get(); }
+    ID3D12RootSignature* GetComputeRootSignature() const { return rootSignatureForCompute_.Get(); }
+
     Model* FindSameModel(const std::string& _name);
     Model* Create(const std::string& _name);
 private:
+
+    void CreateComputePipeline();
 
     std::unordered_map < std::string, std::unique_ptr<Model>> models_ = {};
 
@@ -31,6 +36,8 @@ private:
 
     ID3D12PipelineState* graphicsPipelineStateForAlpha_ = {};
 
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipeline_ = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> rootSignatureForCompute_ = nullptr;
 
     PSOFlags psoFlags_ = {};
     PSOFlags psoFlagsForAlpha_{};

--- a/Engine/Features/Model/Material/Material.cpp
+++ b/Engine/Features/Model/Material/Material.cpp
@@ -41,7 +41,7 @@ void Material::TransferData()
 	Matrix4x4 affine = uvTransform_.GetMatrix();
 
 	constMap_->uvTransform = affine;
-    constMap_->deffuseColor = Vector4(deffuseColor_.x, deffuseColor_.y, deffuseColor_.z, 1.0f);
+	constMap_->deffuseColor = deffuseColor_;
 	constMap_->shininess = shiness_;
 	constMap_->enabledLighthig = enableLighting_;
     constMap_->hasTexture = hasTexture_ ? 1 : 0;
@@ -65,7 +65,7 @@ void Material::TextureQueueCommand(ID3D12GraphicsCommandList* _commandList, UINT
 void Material::AnalyzeMaterial(const aiMaterial* _material)
 {
     aiUVTransform uvTransform;
-	if (_material->Get(AI_MATKEY_UVTRANSFORM(aiTextureType_DIFFUSE, 0), uvTransform_) == AI_SUCCESS)
+	if (_material->Get(AI_MATKEY_UVTRANSFORM(aiTextureType_DIFFUSE, 0), uvTransform) == AI_SUCCESS)
 	{
         uvTransform_.SetOffset(Vector2(uvTransform.mTranslation.x, uvTransform.mTranslation.y));
         uvTransform_.SetScale(Vector2(uvTransform.mScaling.x, uvTransform.mScaling.y));
@@ -81,11 +81,11 @@ void Material::AnalyzeMaterial(const aiMaterial* _material)
 	aiColor3D meshColor;
 	if (_material->Get(AI_MATKEY_COLOR_DIFFUSE, meshColor) == AI_SUCCESS)
 	{
-        deffuseColor_ = Vector3(meshColor.r, meshColor.g, meshColor.b);
+		deffuseColor_ = Vector4(meshColor.r, meshColor.g, meshColor.b, 1.0f);
 	}
     else
     {
-        deffuseColor_ = Vector3(1.0f, 1.0f, 1.0f); // デフォルトの色
+        deffuseColor_ = Vector4(1.0f, 1.0f, 1.0f, 1.0f); // デフォルトの色
     }
     if (_material->Get(AI_MATKEY_SHININESS, shiness_) != AI_SUCCESS)
     {

--- a/Engine/Features/Model/Material/Material.h
+++ b/Engine/Features/Model/Material/Material.h
@@ -31,6 +31,8 @@ public:
 
     UVTransform& GetUVTransform() { return uvTransform_; }
 
+    void SetColor(const Vector4& _color) { deffuseColor_ = _color; }
+
 
     void TransferData();
     void MaterialQueueCommand(ID3D12GraphicsCommandList* _commandList,UINT _index) const;
@@ -44,7 +46,7 @@ private:
 private:
 
     UVTransform     uvTransform_ = {};
-    Vector3 deffuseColor_ = { 1.0f, 1.0f, 1.0f }; // ディフューズカラー
+    Vector4 deffuseColor_ = { 1.0f, 1.0f, 1.0f , 1.0f }; // ディフューズカラー
     bool hasTexture_ = true;
 
     std::string     name_                           = {};

--- a/Engine/Features/Model/Model.cpp
+++ b/Engine/Features/Model/Model.cpp
@@ -134,67 +134,153 @@ Model* Model::CreateFromVertices(std::vector<VertexData> _vertices, std::vector<
 }
 
 
-void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList) const
-{
-    QueueLightCommand(_commandList, 5);
-
-    for (auto& mesh : mesh_)
-    {
-        mesh->QueueCommand(_commandList);
-        material_[mesh->GetUseMaterialIndex()]->TransferData();
-        material_[mesh->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
-        material_[mesh->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4);
-        _commandList->DrawIndexedInstanced(mesh->GetIndexNum(), 1, 0, 0, 0);
-    }
-}
-
-void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_t _textureHandle) const
-{
-    QueueLightCommand(_commandList, 5);
-
-    for (auto& mesh : mesh_)
-    {
-        mesh->QueueCommand(_commandList);
-        material_[mesh->GetUseMaterialIndex()]->TransferData();
-        material_[mesh->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
-        material_[mesh->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4, _textureHandle);
-        _commandList->DrawIndexedInstanced(mesh->GetIndexNum(), 1, 0, 0, 0);
-    }
-}
-
 void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, MargedMesh* _margedMesh) const
 {
-    _commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    _margedMesh->QueueCommand(_commandList);
-    for (size_t meshIndex = 0; meshIndex < _margedMesh->GetMeshCount(); ++meshIndex)
-    {
-        UINT vertexOffset = _margedMesh->GetVertexOffset(meshIndex);
-        UINT indexOffset = _margedMesh->GetIndexOffset(meshIndex);
-        UINT indexCount = _margedMesh->GetIndexCount(meshIndex);
+    QueueLightCommand(_commandList, 5);
 
-        material_[mesh_[meshIndex]->GetUseMaterialIndex()]->TransferData();
-        material_[mesh_[meshIndex]->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
-        material_[mesh_[meshIndex]->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4);
-        _commandList->DrawIndexedInstanced(indexCount, 1, indexOffset, vertexOffset, 0);
+    if (_margedMesh)
+    {
+        _commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        _margedMesh->QueueCommand(_commandList);
+        for (size_t meshIndex = 0; meshIndex < _margedMesh->GetMeshCount(); ++meshIndex)
+        {
+            UINT vertexOffset = _margedMesh->GetVertexOffset(meshIndex);
+            UINT indexOffset = _margedMesh->GetIndexOffset(meshIndex);
+            UINT indexCount = _margedMesh->GetIndexCount(meshIndex);
+
+            size_t materialIndex = mesh_[meshIndex]->GetUseMaterialIndex();
+
+            material_[materialIndex]->MaterialQueueCommand(_commandList, 2);
+            material_[materialIndex]->TransferData();
+            material_[materialIndex]->TextureQueueCommand(_commandList, 4);
+            _commandList->DrawIndexedInstanced(indexCount, 1, indexOffset, vertexOffset, 0);
+        }
+    }
+
+    else
+    {
+        for (auto& mesh : mesh_)
+        {
+            mesh->QueueCommand(_commandList);
+            material_[mesh->GetUseMaterialIndex()]->TransferData();
+            material_[mesh->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
+            material_[mesh->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4);
+            _commandList->DrawIndexedInstanced(mesh->GetIndexNum(), 1, 0, 0, 0);
+        }
     }
 }
 
-void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, MargedMesh* _margedMesh, uint32_t _textureHandle) const
+void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_t _textureHandle, MargedMesh* _margedMesh) const
 {
-    _commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    _margedMesh->QueueCommand(_commandList);
-    for (size_t meshIndex = 0; meshIndex < _margedMesh->GetMeshCount(); ++meshIndex)
-    {
-        UINT vertexOffset = _margedMesh->GetVertexOffset(meshIndex);
-        UINT indexOffset = _margedMesh->GetIndexOffset(meshIndex);
-        UINT indexCount = _margedMesh->GetIndexCount(meshIndex);
+    QueueLightCommand(_commandList, 5);
 
-        material_[mesh_[meshIndex]->GetUseMaterialIndex()]->TransferData();
-        material_[mesh_[meshIndex]->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
-        material_[mesh_[meshIndex]->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4,_textureHandle);
-        _commandList->DrawIndexedInstanced(indexCount, 1, indexOffset, vertexOffset, 0);
+    if (_margedMesh)
+    {
+        _commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        _margedMesh->QueueCommand(_commandList);
+        for (size_t meshIndex = 0; meshIndex < _margedMesh->GetMeshCount(); ++meshIndex)
+        {
+            UINT vertexOffset = _margedMesh->GetVertexOffset(meshIndex);
+            UINT indexOffset = _margedMesh->GetIndexOffset(meshIndex);
+            UINT indexCount = _margedMesh->GetIndexCount(meshIndex);
+
+            size_t materialIndex = mesh_[meshIndex]->GetUseMaterialIndex();
+
+            material_[materialIndex]->MaterialQueueCommand(_commandList, 2);
+            material_[materialIndex]->TransferData();
+            material_[materialIndex]->TextureQueueCommand(_commandList, 4, _textureHandle);
+            _commandList->DrawIndexedInstanced(indexCount, 1, indexOffset, vertexOffset, 0);
+        }
+    }
+    else
+    {
+        for (auto& mesh : mesh_)
+        {
+            mesh->QueueCommand(_commandList);
+            material_[mesh->GetUseMaterialIndex()]->TransferData();
+            material_[mesh->GetUseMaterialIndex()]->MaterialQueueCommand(_commandList, 2);
+            material_[mesh->GetUseMaterialIndex()]->TextureQueueCommand(_commandList, 4, _textureHandle);
+            _commandList->DrawIndexedInstanced(mesh->GetIndexNum(), 1, 0, 0, 0);
+        }
     }
 }
+
+void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, const Vector4& _color, MargedMesh* _margedMesh) const
+{
+    QueueLightCommand(_commandList, 5);
+
+    if (_margedMesh)
+    {
+        _commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        _margedMesh->QueueCommand(_commandList);
+        for (size_t meshIndex = 0; meshIndex < _margedMesh->GetMeshCount(); ++meshIndex)
+        {
+            UINT vertexOffset = _margedMesh->GetVertexOffset(meshIndex);
+            UINT indexOffset = _margedMesh->GetIndexOffset(meshIndex);
+            UINT indexCount = _margedMesh->GetIndexCount(meshIndex);
+
+            size_t materialIndex = mesh_[meshIndex]->GetUseMaterialIndex();
+            material_[materialIndex]->SetColor(_color);
+            material_[materialIndex]->MaterialQueueCommand(_commandList, 2);
+            material_[materialIndex]->TransferData();
+            material_[materialIndex]->TextureQueueCommand(_commandList, 4);
+            _commandList->DrawIndexedInstanced(indexCount, 1, indexOffset, vertexOffset, 0);
+        }
+    }
+    else
+    {
+        for (auto& mesh : mesh_)
+        {
+            mesh->QueueCommand(_commandList);
+            size_t materialIndex = mesh->GetUseMaterialIndex();
+
+            material_[materialIndex]->SetColor(_color);
+            material_[materialIndex]->TransferData();
+            material_[materialIndex]->MaterialQueueCommand(_commandList, 2);
+            material_[materialIndex]->TextureQueueCommand(_commandList, 4);
+            _commandList->DrawIndexedInstanced(mesh->GetIndexNum(), 1, 0, 0, 0);
+        }
+    }
+}
+
+void Model::QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_t _textureHandle, const Vector4& _color, MargedMesh* _margedMesh) const
+{
+    QueueLightCommand(_commandList, 5);
+
+    if (_margedMesh)
+    {
+        _commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        _margedMesh->QueueCommand(_commandList);
+        for (size_t meshIndex = 0; meshIndex < _margedMesh->GetMeshCount(); ++meshIndex)
+        {
+            UINT vertexOffset = _margedMesh->GetVertexOffset(meshIndex);
+            UINT indexOffset = _margedMesh->GetIndexOffset(meshIndex);
+            UINT indexCount = _margedMesh->GetIndexCount(meshIndex);
+
+            size_t materialIndex = mesh_[meshIndex]->GetUseMaterialIndex();
+            material_[materialIndex]->SetColor(_color);
+            material_[materialIndex]->MaterialQueueCommand(_commandList, 2);
+            material_[materialIndex]->TransferData();
+            material_[materialIndex]->TextureQueueCommand(_commandList, 4, _textureHandle);
+            _commandList->DrawIndexedInstanced(indexCount, 1, indexOffset, vertexOffset, 0);
+        }
+    }
+    else
+    {
+        for (auto& mesh : mesh_)
+        {
+            mesh->QueueCommand(_commandList);
+            size_t materialIndex = mesh->GetUseMaterialIndex();
+
+            material_[materialIndex]->SetColor(_color);
+            material_[materialIndex]->TransferData();
+            material_[materialIndex]->MaterialQueueCommand(_commandList, 2);
+            material_[materialIndex]->TextureQueueCommand(_commandList, 4, _textureHandle);
+            _commandList->DrawIndexedInstanced(mesh->GetIndexNum(), 1, 0, 0, 0);
+        }
+    }
+}
+
 
 void Model::QueueCommandForShadow(ID3D12GraphicsCommandList* _commandList) const
 {

--- a/Engine/Features/Model/Model.h
+++ b/Engine/Features/Model/Model.h
@@ -39,11 +39,10 @@ public:
     void Draw(const WorldTransform& _transform, const Camera* _camera, uint32_t _textureHandle, ObjectColor* _color);
     void Draw(const WorldTransform& _transform, const Camera* _camera, ObjectColor* _color);
 
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList) const;
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList,uint32_t _textureHandle) const;
-
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, MargedMesh* _margedMesh) const;
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, MargedMesh* _margedMesh, uint32_t _textureHandle) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, MargedMesh* _margedMesh = nullptr) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList,uint32_t _textureHandle, MargedMesh* _margedMesh = nullptr) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, const Vector4& _color, MargedMesh* _margedMesh = nullptr) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_t _textureHandle, const Vector4& _color, MargedMesh* _margedMesh = nullptr) const;
 
     void QueueCommandForShadow(ID3D12GraphicsCommandList* _commandList) const;
 

--- a/Engine/Features/Model/ObjectModel.h
+++ b/Engine/Features/Model/ObjectModel.h
@@ -30,8 +30,7 @@ public:
     void SetAnimation(const std::string& _name, bool _isLoop = false);
     void ChangeAnimation(const std::string& _name, float _blendTime, bool _isLoop = false);
 
-    //TODO
-    //bool IsEndAnimation() const { return !model_->IsAnimationPlaying(); }
+    bool IsEndAnimation() const { return !animationController_ || !animationController_->IsAnimationPlaying(); }
 
     void SetModel(const std::string& _filePath);
     void SetParent(const WorldTransform* _parent) { worldTransform_.parent_ = _parent; }


### PR DESCRIPTION
条件分岐等で正常に動作するように

TODO
アニメーションを個別に再生できるように設定したがあまりにも重い(それはそう)

アニメーションコントローラと描画処理の改善

- AnimationControllerのコンストラクタを変更し、初期化メソッドを追加。スキニングシェーダーの初期化に必要なパイプラインステートとルートシグネチャを受け取るように。
- Skeletonクラスにデバッグ用のImGuiメソッドを追加。
- SkinningCSクラスのコンストラクタを変更し、リソース初期化処理を簡略化。
- ModelManagerにCreateComputePipelineメソッドを追加し、コンピュートパイプラインの作成処理を実装。
- MaterialクラスにSetColorメソッドを追加し、色のデータ型をVector3からVector4に変更。
- ModelクラスのQueueCommandAndDrawメソッドをオーバーロードし、マージされたメッシュを引数に取るように。
- ObjectModelクラスのアニメーションコントローラの初期化処理を強化し、アニメーションが存在する場合のみ初期化。
- ObjectModelの描画メソッドを変更し、アニメーションコントローラが存在する場合にマージされたメッシュを使用して描画。