### PR TITLE
SpiralHashGridをSpatialHashGridに変更

### DIFF
--- a/Engine/Features/Collision/Manager/CollisionManager.cpp
+++ b/Engine/Features/Collision/Manager/CollisionManager.cpp
@@ -20,7 +20,7 @@ void CollisionManager::Initialize(const Vector2& _fieldSize, uint32_t _level, co
     quadTree_->Initialize(_fieldSize, _level, _leftBotom);
 
     // スパイラルハッシュグリッドの初期化
-    spiralHashGrid_ = std::make_unique<SpiralHashGrid>(_gridSize);
+    spiralHashGrid_ = std::make_unique<SpatialHashGrid>(_gridSize);
     spiralHashGrid_->Clear();
 }
 
@@ -112,26 +112,11 @@ void CollisionManager::CheckCollisions()
         for (size_t j = i + 1; j < colliders_.size(); ++j)
         {
             Collider* colliderB = colliders_[j];
-
-            // レイヤーマスクでフィルタリング
-            if ((colliderA->GetLayer() & colliderB->GetLayerMask()) != 0 ||
-                (colliderB->GetLayer() & colliderA->GetLayerMask()) != 0)
-            {
-                continue; // 衝突しないように設定されている
-            }
-
             potentialCollisions_.emplace_back(colliderA, colliderB);
         }
         for (auto& staticColliders_ : staticColliders_)
         {
             Collider* colliderB = staticColliders_;
-
-            // レイヤーマスクでフィルタリング
-            if ((colliderA->GetLayer() & colliderB->GetLayerMask()) != 0 ||
-                (colliderB->GetLayer() & colliderA->GetLayerMask()) != 0)
-            {
-                continue; // 衝突しないように設定されている
-            }
             potentialCollisions_.emplace_back(colliderA, colliderB);
         }
     }

--- a/Engine/Features/Collision/Manager/CollisionManager.h
+++ b/Engine/Features/Collision/Manager/CollisionManager.h
@@ -2,7 +2,7 @@
 #include <Features/Collision/Collider/Collider.h>
 #include <Features/Collision/Detector/CollisionDetector.h>
 #include <Features/Collision/Tree/QuadTree.h>
-#include <Features/Collision/SpiralHashGird/SpiralHashGrid.h>
+#include <Features/Collision/SpiralHashGird/SpatialHashGrid.h>
 #include <vector>
 #include <unordered_map>
 #include <functional>
@@ -86,7 +86,7 @@ private:
     std::unique_ptr<QuadTree> quadTree_;
 
     // スパイラルハッシュグリッド
-    std::unique_ptr<SpiralHashGrid> spiralHashGrid_;
+    std::unique_ptr<SpatialHashGrid> spiralHashGrid_;
 
 #ifdef _DEBUG
     // デバッグ用の衝突検出器

--- a/Engine/Features/Collision/SpiralHashGird/SpatialHashGrid.cpp
+++ b/Engine/Features/Collision/SpiralHashGird/SpatialHashGrid.cpp
@@ -1,10 +1,10 @@
-#include "SpiralHashGrid.h"
+#include "SpatialHashGrid.h"
 
 #include <set>
 #include <array>
 #include <Features/LineDrawer/LineDrawer.h>
 
-void SpiralHashGrid::AddCollider(Collider* _collider)
+void SpatialHashGrid::AddCollider(Collider* _collider)
 {
     std::array<int32_t, 4> cellIndices = GetCellIndices(_collider);
 
@@ -18,7 +18,7 @@ void SpiralHashGrid::AddCollider(Collider* _collider)
     }
 }
 
-void SpiralHashGrid::RemoveCollider(Collider* _collider)
+void SpatialHashGrid::RemoveCollider(Collider* _collider)
 {
     std::array<int32_t, 4> cellIndices = GetCellIndices(_collider);
 
@@ -43,7 +43,7 @@ void SpiralHashGrid::RemoveCollider(Collider* _collider)
     }
 }
 
-std::vector<Collider*> SpiralHashGrid::CheckCollision(Collider* _col) const
+std::vector<Collider*> SpatialHashGrid::CheckCollision(Collider* _col) const
 {
     std::set<Collider*> result;
 
@@ -96,7 +96,7 @@ std::vector<Collider*> SpiralHashGrid::CheckCollision(Collider* _col) const
     return std::vector<Collider*>(result.begin(), result.end());
 }
 
-uint64_t SpiralHashGrid::GetHashKey(const Vector2& _position) const
+uint64_t SpatialHashGrid::GetHashKey(const Vector2& _position) const
 {
     int32_t x = static_cast<int32_t>(_position.x / cellSize_);
     int32_t y = static_cast<int32_t>(_position.y / cellSize_);
@@ -105,7 +105,7 @@ uint64_t SpiralHashGrid::GetHashKey(const Vector2& _position) const
 
 }
 
-uint64_t SpiralHashGrid::GetHashKey(int32_t _x, int32_t _y) const
+uint64_t SpatialHashGrid::GetHashKey(int32_t _x, int32_t _y) const
 {
     // 負の値も正しく処理するためのオフセット
     uint32_t ux = static_cast<uint32_t>(_x);
@@ -114,7 +114,7 @@ uint64_t SpiralHashGrid::GetHashKey(int32_t _x, int32_t _y) const
     return (static_cast<uint64_t>(ux) << 32) | static_cast<uint64_t>(uy);
 }
 
-std::array<int32_t, 4> SpiralHashGrid::GetCellIndices(Collider* _col) const
+std::array<int32_t, 4> SpatialHashGrid::GetCellIndices(Collider* _col) const
 {
     Vector3 position3 = _col->GetWorldTransform()->GetWorldPosition();
     Vector2 center = Vector2(position3.x, position3.z);
@@ -132,7 +132,7 @@ std::array<int32_t, 4> SpiralHashGrid::GetCellIndices(Collider* _col) const
 
 }
 
-std::array<int32_t, 4> SpiralHashGrid::GetCellIndices(const AABB& _aabb) const
+std::array<int32_t, 4> SpatialHashGrid::GetCellIndices(const AABB& _aabb) const
 {
     Vector2 min = Vector2(_aabb.min.x, _aabb.min.z);
     Vector2 max = Vector2(_aabb.max.x, _aabb.max.z);

--- a/Engine/Features/Collision/SpiralHashGird/SpatialHashGrid.h
+++ b/Engine/Features/Collision/SpiralHashGird/SpatialHashGrid.h
@@ -7,11 +7,11 @@
 #include <unordered_map>
 #include <vector>
 
-class SpiralHashGrid
+class SpatialHashGrid
 {
 public:
-    SpiralHashGrid(float _cellSize) : cellSize_(_cellSize) {};
-    ~SpiralHashGrid() = default;
+    SpatialHashGrid(float _cellSize) : cellSize_(_cellSize) {};
+    ~SpatialHashGrid() = default;
 
     void Clear() { grid_.clear(); }
     void Reset() { Clear(); }

--- a/Engine/Features/Model/ObjectModel.cpp
+++ b/Engine/Features/Model/ObjectModel.cpp
@@ -82,13 +82,22 @@ void ObjectModel::Draw(const Camera* _camera)
     worldTransform_.QueueCommand(commandList, 1);
     objectColor_->QueueCommand(commandList, 3);
 
-    if (animationController_)
-        model_->QueueCommandAndDraw(commandList, animationController_->GetMargedMesh());
+    if (uniqueAnimationController_)
+        model_->QueueCommandAndDraw(commandList, uniqueAnimationController_->GetMargedMesh());
+    else if (sharedAnimationController_)
+        model_->QueueCommandAndDraw(commandList, sharedAnimationController_->GetMargedMesh());
     else
         model_->QueueCommandAndDraw(commandList);
 
     if (drawSkeleton_)
-        animationController_->DrawSkeleton(worldTransform_.matWorld_);
+    {
+        if (uniqueAnimationController_)
+            uniqueAnimationController_->DrawSkeleton(worldTransform_.matWorld_);
+        else if (sharedAnimationController_)
+            sharedAnimationController_->DrawSkeleton(worldTransform_.matWorld_);
+
+    }
+
 }
 
 void ObjectModel::Draw(const Camera* _camera, const Vector4& _color)

--- a/Engine/GameEngine.vcxproj
+++ b/Engine/GameEngine.vcxproj
@@ -167,7 +167,7 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClCompile Include="Features\Collision\RayCast\Ray.cpp" />
     <ClCompile Include="Features\Collision\RayCast\RayCollisionManager.cpp" />
     <ClCompile Include="Features\Collision\Shapes.cpp" />
-    <ClCompile Include="Features\Collision\SpiralHashGird\SpiralHashGrid.cpp" />
+    <ClCompile Include="Features\Collision\SpiralHashGird\SpatialHashGrid.cpp" />
     <ClCompile Include="Features\Collision\Tree\Cell.cpp" />
     <ClCompile Include="Features\Collision\Tree\QuadTree.cpp" />
     <ClCompile Include="Features\Effect\Editor\ParticleEditor.cpp" />
@@ -277,7 +277,7 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClInclude Include="Features\Collision\RayCast\Ray.h" />
     <ClInclude Include="Features\Collision\RayCast\RayCollisionManager.h" />
     <ClInclude Include="Features\Collision\Shapes.h" />
-    <ClInclude Include="Features\Collision\SpiralHashGird\SpiralHashGrid.h" />
+    <ClInclude Include="Features\Collision\SpiralHashGird\SpatialHashGrid.h" />
     <ClInclude Include="Features\Collision\Tree\Cell.h" />
     <ClInclude Include="Features\Collision\Tree\QuadTree.h" />
     <ClInclude Include="Features\Effect\Editor\ParticleEditor.h" />

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -223,9 +223,6 @@
     <Filter Include="Features\Collision\Tree">
       <UniqueIdentifier>{a01a5b5e-fd33-4c0b-9cf1-f26c55606ed6}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Features\Collision\SpiralHashGrid">
-      <UniqueIdentifier>{8ccabc1c-898d-4356-9e85-abbf31094bee}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Features\LevelEditor">
       <UniqueIdentifier>{e3c280d0-a343-413f-93ac-a4ce660ca9cf}</UniqueIdentifier>
     </Filter>
@@ -249,6 +246,9 @@
     </Filter>
     <Filter Include="Shaders\PostEffects">
       <UniqueIdentifier>{7e57f265-25f1-4991-8573-e6274ac52084}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Features\Collision\SpatialHashGrid">
+      <UniqueIdentifier>{8ccabc1c-898d-4356-9e85-abbf31094bee}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -540,8 +540,8 @@
     <ClCompile Include="Features\Collision\Tree\QuadTree.cpp">
       <Filter>Features\Collision\Tree</Filter>
     </ClCompile>
-    <ClCompile Include="Features\Collision\SpiralHashGird\SpiralHashGrid.cpp">
-      <Filter>Features\Collision\SpiralHashGrid</Filter>
+    <ClCompile Include="Features\Collision\SpiralHashGird\SpatialHashGrid.cpp">
+      <Filter>Features\Collision\SpatialHashGrid</Filter>
     </ClCompile>
     <ClCompile Include="Features\Effect\Modifier\Preset\RotationBasedMovementModifier.cpp">
       <Filter>Features\Effect\Modifier\Preset</Filter>
@@ -933,8 +933,8 @@
     <ClInclude Include="Features\Collision\Tree\QuadTree.h">
       <Filter>Features\Collision\Tree</Filter>
     </ClInclude>
-    <ClInclude Include="Features\Collision\SpiralHashGird\SpiralHashGrid.h">
-      <Filter>Features\Collision\SpiralHashGrid</Filter>
+    <ClInclude Include="Features\Collision\SpiralHashGird\SpatialHashGrid.h">
+      <Filter>Features\Collision\SpatialHashGrid</Filter>
     </ClInclude>
     <ClInclude Include="Features\Scene\SceneData.h">
       <Filter>Features\Scene</Filter>


### PR DESCRIPTION
- `SpiralHashGrid` から `SpatialHashGrid` への名前変更を実施し、関連するファイル名、クラス名、インクルードパスを更新。
- `CollisionManager` クラスの `Initialize` メソッドで、`SpatialHashGrid` のインスタンス作成に変更。
- `CollisionManager` クラスの `CheckCollisions` メソッドからレイヤーマスクによるフィルタリングコードを削除し、衝突判定ロジックを簡素化。
- `SpatialHashGrid` クラスのメソッド名をすべて更新し、実装を修正。
- `ObjectModel` クラスの `Draw` メソッドで、アニメーションコントローラーの条件分岐を変更し、両方のコントローラーに対応。
- プロジェクトファイル（`.vcxproj`）とフィルターファイル（`.vcxproj.filters`）で、`SpiralHashGrid` に関連するエントリを `SpatialHashGrid` に更新。