### PR TITLE
ボタンナビゲーションと改善とデフォコールバック関数の追加と改修

### DIFF
--- a/Engine/Features/UI/ButtonNavigator.cpp
+++ b/Engine/Features/UI/ButtonNavigator.cpp
@@ -34,7 +34,7 @@ void ButtonNavigator::Update()
         // マウスが動いた場合,マウスによるフォーカスをチェック
         CheckButtonFocus();
     }
-    else if (Direction dir = GetDirectionFromInput(); dir != Direction::None)
+    if (Direction dir = GetDirectionFromInput(); dir != Direction::None)
     {
         if (currentFocusedButton_)
         {

--- a/Engine/Features/UI/UIButton.cpp
+++ b/Engine/Features/UI/UIButton.cpp
@@ -16,8 +16,8 @@ UIButton::UIButton() :
     onFocusGained_([this]() {OnFocusGained(); }),
     onFocusLost_([this]() {OnFocusLost(); }),
     onFocusUpdate_(nullptr),
-    onClickStart_(nullptr),
-    onClickEnd_(nullptr)
+    onClickStart_([this]() {OnClickStart(); }),
+    onClickEnd_([this]() {OnClickEnd(); })
 {
 }
 
@@ -181,4 +181,17 @@ void UIButton::OnFocusGained()
 void UIButton::OnFocusLost()
 {
     color_ = defaultColor;
+}
+
+void UIButton::OnClickStart()
+{
+    // クリック開始時の処理
+    isClickEnd_ = true; // クリック終了フラグをリセット
+    isTrigered_ = false;
+}
+
+void UIButton::OnClickEnd()
+{
+    // クリック終了時の処理
+    isClickEnd_ = false; // クリック終了フラグをリセット
 }

--- a/Engine/Features/UI/UIButton.h
+++ b/Engine/Features/UI/UIButton.h
@@ -75,7 +75,8 @@ private:
     // デフォルトコールバック
     void OnFocusGained();
     void OnFocusLost();
-
+    void OnClickStart();
+    void OnClickEnd();
 private:
 
     // ナビゲーションのターゲット


### PR DESCRIPTION
- `ButtonNavigator::Update()` メソッドの条件文を修正し、マウスの動きが閾値を超えない場合でも方向を取得するように変更。
- `UIButton` コンストラクタで `onClickStart_` と `onClickEnd_` の初期化をラムダ式を使用して変更。
- `UIButton` クラスに `OnClickStart()` と `OnClickEnd()` メソッドを追加し、クリックの状態を管理する処理を実装。
- `UIButton.h` に `OnClickStart()` と `OnClickEnd()` メソッドの宣言を追加。