### PR TITLE
Text周りのクラスの改修。シングルトンをやめて複数のフォント，サイズで描画できるようにした

### DIFF
--- a/Engine/Features/TextRenderer/AtlasData.cpp
+++ b/Engine/Features/TextRenderer/AtlasData.cpp
@@ -1,0 +1,307 @@
+#include "AtlasData.h"
+
+#include <Core/DXCommon/DXCommon.h>
+#include <Core/DXCommon/SRVManager/SRVManager.h>
+
+#include <fstream>
+#include <cassert>
+
+void AtlasData::Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* _cmdList, const Vector2& _windowSize, const std::string& _fontFilePath, float _fontSize,const Vector2& _atlasSize)
+{
+    if (!_device || !_cmdList)
+        return;
+
+    device_ = _device;
+    cmdList_ = _cmdList;
+
+    atlasSize_ = _atlasSize;
+
+    srvManager_ = SRVManager::GetInstance();
+    dxCommon_ = DXCommon::GetInstance();
+
+    fontSize_ = _fontSize;
+
+    atlasData_.resize(static_cast<size_t>(atlasSize_.x * atlasSize_.y), 0);
+    currentX_ = 0;
+    currentY_ = 0;
+    maxY_ = 0;
+    atlasNeedsUpdate_ = false;
+
+    // フォント読み込み
+    LoadFont(_fontFilePath, _fontSize);
+
+    // フォントテクスチャの作成
+    CreateFontTexture();
+
+    // 文字の事前読み込み
+    PreloadCommonCharacters();
+
+    if (atlasNeedsUpdate_)
+    {
+        UpdateFontTexture();
+        atlasNeedsUpdate_ = false;
+    }
+
+}
+
+void AtlasData::LoadFont(const std::string& _fontFilePath, float _fontSize)
+{
+    std::ifstream file(_fontFilePath, std::ios::binary);
+    if (!file.is_open())
+    {
+        assert("Failed to open font file");
+        return;
+    }
+
+    file.seekg(0, std::ios::end);
+    size_t fileSize = static_cast<size_t>(file.tellg());
+    file.seekg(0, std::ios::beg);
+
+    fontBuffer_.resize(fileSize);
+    file.read(reinterpret_cast<char*>(fontBuffer_.data()), fileSize);
+    file.close();
+
+    if (!stbtt_InitFont(&fontInfo_, fontBuffer_.data(), 0))
+    {
+        assert("Failed to initialize font");
+        return;
+    }
+
+    scale_ = stbtt_ScaleForPixelHeight(&fontInfo_, _fontSize);
+
+    int ascent, descent, lineGap;
+    stbtt_GetFontVMetrics(&fontInfo_, &ascent, &descent, &lineGap);
+
+    // スケールを掛けてfloat型に変換
+    fontAscent_ = ascent * scale_;
+    fontDescent_ = descent * scale_;
+    fontLineGap_ = lineGap * scale_;
+}
+
+void AtlasData::CreateFontTexture()
+{
+    D3D12_RESOURCE_DESC texDesc = {};
+    texDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    texDesc.Width = static_cast<UINT64>(atlasSize_.x);
+    texDesc.Height = static_cast<UINT>(atlasSize_.y);
+    texDesc.DepthOrArraySize = 1;
+    texDesc.MipLevels = 1;
+    texDesc.Format = DXGI_FORMAT_R8_UNORM;
+    texDesc.SampleDesc.Count = 1;
+    texDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    texDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+    D3D12_HEAP_PROPERTIES heapProps = {};
+    heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+
+    HRESULT hr = device_->CreateCommittedResource(
+        &heapProps, D3D12_HEAP_FLAG_NONE, &texDesc,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
+        IID_PPV_ARGS(&fontTexture_));
+
+    if (FAILED(hr))
+    {
+        assert("Failed to create font texture resource");
+        return;
+    }
+
+    textureIndex_= srvManager_->Allocate();
+    srvManager_->CreateSRVForTextrue2D(textureIndex_, fontTexture_.Get(), DXGI_FORMAT_R8_UNORM, 1);
+
+    size_t uploadBufferSize = static_cast<size_t>(atlasSize_.x * atlasSize_.y);
+
+    uploadBuffer_ = dxCommon_->CreateBufferResource(static_cast<uint32_t>(uploadBufferSize));
+}
+
+void AtlasData::UpdateFontTexture()
+{// アップロード用の中間バッファ作成
+    size_t uploadBufferSize = static_cast<size_t>(atlasSize_.x * atlasSize_.y);
+
+    // データをアップロードバッファにコピー
+    void* mappedData;
+    HRESULT hr = uploadBuffer_->Map(0, nullptr, &mappedData);
+    if (SUCCEEDED(hr))
+    {
+        memcpy(mappedData, atlasData_.data(), uploadBufferSize);
+        uploadBuffer_->Unmap(0, nullptr);
+    }
+
+    // テクスチャコピー情報設定
+    D3D12_TEXTURE_COPY_LOCATION srcLocation = {};
+    srcLocation.pResource = uploadBuffer_.Get();
+    srcLocation.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+    srcLocation.PlacedFootprint.Offset = 0;
+    srcLocation.PlacedFootprint.Footprint.Format = DXGI_FORMAT_R8_UNORM;
+    srcLocation.PlacedFootprint.Footprint.Width = static_cast<UINT>(atlasSize_.x);
+    srcLocation.PlacedFootprint.Footprint.Height = static_cast<UINT>(atlasSize_.y);
+    srcLocation.PlacedFootprint.Footprint.Depth = 1;
+    srcLocation.PlacedFootprint.Footprint.RowPitch = static_cast<UINT>(atlasSize_.x);
+
+    D3D12_TEXTURE_COPY_LOCATION dstLocation = {};
+    dstLocation.pResource = fontTexture_.Get();
+    dstLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+    dstLocation.SubresourceIndex = 0;
+
+    // リソース状態遷移
+    D3D12_RESOURCE_BARRIER barrier = {};
+    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    barrier.Transition.pResource = fontTexture_.Get();
+    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    cmdList_->ResourceBarrier(1, &barrier);
+
+    // テクスチャコピー実行
+    cmdList_->CopyTextureRegion(&dstLocation, 0, 0, 0, &srcLocation, nullptr);
+
+    // リソース状態を戻す
+    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+    cmdList_->ResourceBarrier(1, &barrier);
+}
+
+void AtlasData::PreloadCommonCharacters()
+{
+    for (char c = 32; c < 127; c++)
+    {
+        GetGlyph(static_cast<wchar_t>(c));
+    }
+}
+
+Vector2 AtlasData::GetStringAreaSize(const std::wstring& _text, const Vector2& _scale)
+{
+    Vector2 area = {};
+    if (_text.empty()) return area;
+
+    float currentX = 0.0f;
+    float currentY = 0.0f;
+    float maxWidth = 0.0f;
+    float lineHeight = fontSize_ * _scale.y;
+
+    for (size_t i = 0; i < _text.length(); ++i)
+    {
+        wchar_t character = _text[i];
+        // 改行処理
+        if (character == L'\n')
+        {
+            currentX = 0.0f;
+            currentY += lineHeight;
+            maxWidth = (std::max)(maxWidth, currentX);
+
+            continue;
+        }
+        // スペース処理
+        if (character == L' ')
+        {
+            currentX += fontSize_ * 0.3f * _scale.x;  // スペース幅
+            continue;
+        }
+        // グリフ情報取得
+        GlyphInfo glyph = GetGlyph(character);
+        if (!glyph.isValid)
+        {
+            continue;
+        }
+        // 文字の幅を加算
+        currentX += glyph.advance * _scale.x;
+    }
+    area.x = currentX;
+    area.y = currentY + lineHeight;
+
+    if (area.x < 0.0f) area.x = 0.0f;
+    if (area.y < 0.0f) area.y = 0.0f;
+
+    return area;
+
+}
+
+GlyphInfo AtlasData::GetGlyph(wchar_t _character)
+{
+    auto it = glyphs_.find(_character);
+    if (it != glyphs_.end())
+    {
+        return it->second;
+    }
+
+    auto glyph = GenerateGlyph(_character);
+
+    // 新しい文字が生成された場合は即座にテクスチャ更新
+    if (atlasNeedsUpdate_)
+    {
+        UpdateFontTexture();
+        atlasNeedsUpdate_ = false;
+    }
+
+    return glyph;
+}
+
+GlyphInfo AtlasData::GenerateGlyph(wchar_t _character)
+{
+    int width, height, xOffset, yOffset;
+
+    unsigned char* bitmap = stbtt_GetCodepointBitmap(
+        &fontInfo_, 0, scale_, _character,
+        &width, &height, &xOffset, &yOffset);
+
+    GlyphInfo glyph = {};
+
+    if (!bitmap)
+    {
+        // 文字が見つからない場合は□を表示
+        if (_character != L'□')
+        {
+            return GetGlyph(L'□');
+        }
+        glyph.isValid = false;
+        return glyph;
+    }
+
+    // アトラスに配置
+    if (currentX_ + width >= atlasSize_.x)
+    {
+        currentX_ = 0;
+        currentY_ += maxY_;
+        maxY_ = 0;
+    }
+
+    // ビットマップをアトラスにコピー
+    for (int y = 0; y < height; y++)
+    {
+        for (int x = 0; x < width; x++)
+        {
+            int srcIndex = y * width + x;
+            int dstIndex = static_cast<int>(currentY_ + y) * static_cast<int>(atlasSize_.x) + static_cast<int>(currentX_ + x);
+            if (dstIndex < static_cast<int>(atlasData_.size())) {
+                atlasData_[dstIndex] = bitmap[srcIndex];
+            }
+        }
+    }
+
+    // グリフ情報を設定
+    glyph.u0 = static_cast<float>(currentX_) / atlasSize_.x;
+    glyph.v0 = static_cast<float>(currentY_) / atlasSize_.y;
+    glyph.u1 = static_cast<float>(currentX_ + width) / atlasSize_.x;
+    glyph.v1 = static_cast<float>(currentY_ + height) / atlasSize_.y;
+    glyph.width = static_cast<float>(width);
+    glyph.height = static_cast<float>(height);
+    glyph.bearingX = static_cast<float>(xOffset);
+    glyph.bearingY = static_cast<float>(yOffset);
+    glyph.isValid = true;
+
+    // アドバンス幅を取得
+    int advanceWidth, leftSideBearing;
+    stbtt_GetCodepointHMetrics(&fontInfo_, _character, &advanceWidth, &leftSideBearing);
+    glyph.advance = advanceWidth * scale_;
+
+    // 位置を更新
+    currentX_ += width + 1;
+    maxY_ = (std::max)(maxY_, height + 1);
+
+    // キャッシュに保存
+    glyphs_[_character] = glyph;
+    atlasNeedsUpdate_ = true;
+
+    stbtt_FreeBitmap(bitmap, nullptr);
+    return glyph;
+}

--- a/Engine/Features/TextRenderer/AtlasData.h
+++ b/Engine/Features/TextRenderer/AtlasData.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <Externals/stb/stb_truetype.h>
+
+#include <Math/Vector/Vector2.h>
+
+#include <d3d12.h>
+#include <wrl.h>
+
+#include <string>
+#include <unordered_map>
+#include <map>
+
+struct GlyphInfo
+{
+    float u0, v0, u1, v1;      // UV座標
+    float width, height;        // サイズ
+    float bearingX, bearingY;   // オフセット
+    float advance;              // 次の文字までの距離
+    bool isValid = false;
+};
+
+
+struct FontConfig
+{
+    Vector2 atlasSize = { 4096,4096 }; // アトラスの幅
+    float fontSize = 32.0f; // フォントサイズ
+    std::string fontFilePath = "Resources/Fonts/NotoSansJP-Regular.ttf"; // フォントファイルのパス
+};
+
+class DXCommon;
+class SRVManager;
+class  AtlasData
+{
+public:
+
+    void Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* _cmdList, const Vector2& _windowSize, const std::string& _fontFilePath, float _fontSize, const Vector2& _atlasSize);
+
+public: /// アクセッサ
+
+    // フォントテクスチャを取得
+    ID3D12Resource* GetFontTexture() const { return fontTexture_.Get(); }
+
+    // フォントテクスチャのSRVインデックスを取得
+    uint32_t GetFontTextureIndex() const { return textureIndex_; }
+
+    // フォントサイズを取得
+    float GetFontSize() const { return fontSize_; }
+
+    // フォントのアセントを取得
+    float GetFontAscent() const { return fontAscent_; }
+
+    // グリフ情報を取得
+    GlyphInfo GetGlyph(wchar_t _character);
+
+    // テキストエリアを取得する
+    Vector2 GetStringAreaSize(const std::wstring& _text, const Vector2& _scale);
+
+private:
+
+    // フォントの読み込み
+    void LoadFont(const std::string& _fontFilePath, float _fontSize);
+
+    // フォントテクスチャの作成
+    void CreateFontTexture();
+
+    // フォントテクスチャの更新
+    void UpdateFontTexture();
+
+    // 文字の事前読み込み
+    void PreloadCommonCharacters();
+
+    // グリフ情報を生成
+    GlyphInfo GenerateGlyph(wchar_t _character);
+
+private:
+
+    SRVManager* srvManager_; // SRVマネージャー
+    DXCommon* dxCommon_; // DXCommon
+    ID3D12Device* device_; // D3D12デバイス
+    ID3D12GraphicsCommandList* cmdList_; // コマンドリスト
+
+
+    // GPU リソース
+    Microsoft::WRL::ComPtr<ID3D12Resource> fontTexture_;
+    Microsoft::WRL::ComPtr<ID3D12Resource> uploadBuffer_;
+    uint32_t textureIndex_;
+
+    // フォント情報
+    stbtt_fontinfo fontInfo_;
+    std::vector<uint8_t> fontBuffer_;
+    float scale_;
+    float fontSize_;
+
+    // アトラス管理
+    std::vector<uint8_t> atlasData_;
+    Vector2 atlasSize_;
+    int32_t currentX_;
+    int32_t currentY_;
+    int32_t maxY_;
+    std::unordered_map<wchar_t, GlyphInfo> glyphs_;
+    bool atlasNeedsUpdate_;
+
+    // フォントメトリクス
+    float fontAscent_;
+    float fontDescent_;
+    float fontLineGap_;
+
+};

--- a/Engine/Features/TextRenderer/FontCache.cpp
+++ b/Engine/Features/TextRenderer/FontCache.cpp
@@ -1,0 +1,57 @@
+#include "FontCache.h"
+
+#include <Core/DXCommon/DXCommon.h>
+#include <Core/DXCommon/SRVManager/SRVManager.h>
+
+#include <fstream>
+#include <cassert>
+
+
+FontCache* FontCache::GetInstance()
+{
+    static FontCache instance;
+    return &instance;
+}
+
+void FontCache::Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* _cmdList, const Vector2& _windowSize)
+{
+    if (!_device || !_cmdList)
+        return;
+
+    device_ = _device;
+    cmdList_ = _cmdList;
+
+    windowSize_ = _windowSize;
+
+    dxCommon_ = DXCommon::GetInstance();
+    srvManager_ = SRVManager::GetInstance();
+
+    FontConfig config = {};
+
+    auto atlasData = std::make_unique<AtlasData>();
+    atlasData->Initialize(device_, cmdList_, windowSize_, config.fontFilePath, config.fontSize, config.atlasSize);
+
+    atlasDataMap_.emplace(std::make_pair(config.fontFilePath, config.fontSize), std::move(atlasData));
+}
+
+AtlasData* FontCache::GetAtlasData(const std::string& _fontFilePath, float _fontSize)
+{
+    auto pair = std::make_pair(_fontFilePath, _fontSize);
+
+    auto it = atlasDataMap_.find(pair);
+    if (it != atlasDataMap_.end())
+    {
+        return it->second.get();
+    }
+
+    // 存在しない場合は新しく作成
+    auto atlasData = std::make_unique<AtlasData>();
+    atlasData->Initialize(device_, cmdList_, windowSize_, _fontFilePath, _fontSize, { 4096, 4096 });
+
+    AtlasData* atlasPtr = atlasData.get();
+
+    atlasDataMap_.emplace(pair, std::move(atlasData));
+
+    return atlasPtr;
+
+}

--- a/Engine/Features/TextRenderer/FontCache.h
+++ b/Engine/Features/TextRenderer/FontCache.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <Externals/stb/stb_truetype.h>
+
+#include <Math/Vector/Vector2.h>
+
+#include <Features/TextRenderer/AtlasData.h>
+
+#include <d3d12.h>
+#include <wrl.h>
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <map>
+
+class DXCommon;
+class SRVManager;
+class FontCache
+{
+public:
+    static FontCache* GetInstance();
+
+public:
+
+    void Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* _cmdList, const Vector2& _windowSize);
+
+    AtlasData* GetAtlasData(const std::string& _fontFilePath, float _fontSize);
+
+private:
+    ID3D12Device* device_; // D3D12デバイス
+    ID3D12GraphicsCommandList* cmdList_; // コマンドリスト
+
+    SRVManager* srvManager_; // SRVマネージャー
+    DXCommon* dxCommon_; // DXCommon
+
+    Vector2 windowSize_; // ウィンドウサイズ
+
+    //                  fontpath    size    アトラス
+    std::map<std::pair<std::string, float>, std::unique_ptr<AtlasData>> atlasDataMap_; // アトラスデータを格納するマップ
+
+private:
+
+    // singleton
+    FontCache() = default;
+    ~FontCache() = default;
+    FontCache(const FontCache&) = delete;
+    FontCache& operator=(const FontCache&) = delete;
+
+};

--- a/Engine/Features/TextRenderer/TextGenerator.cpp
+++ b/Engine/Features/TextRenderer/TextGenerator.cpp
@@ -1,0 +1,23 @@
+#include "TextGenerator.h"
+
+#include <Features/TextRenderer/FontCache.h>
+#include <Features/TextRenderer/TextRenderer.h>
+
+void TextGenerator::Initialize(const FontConfig& _config)
+{
+    auto fontCache = FontCache::GetInstance();
+
+    atlasData_ = fontCache->GetAtlasData(_config.fontFilePath, _config.fontSize);
+
+    renderer_ = TextRenderer::GetInstance();
+}
+
+void TextGenerator::Draw(const std::wstring& _text, const Vector2& _pos, const Vector4& _color)
+{
+    renderer_->DrawText(_text, atlasData_,_pos, _color);
+}
+
+void TextGenerator::Draw(const std::wstring& _text, const TextParam& _param)
+{
+    renderer_->DrawText(_text, atlasData_, _param);
+}

--- a/Engine/Features/TextRenderer/TextGenerator.h
+++ b/Engine/Features/TextRenderer/TextGenerator.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Features/TextRenderer/AtlasData.h>
+#include <Features/TextRenderer/TextParan.h>
+
+
+#ifdef DrawText
+#undef DrawText
+#endif // DrawText
+
+
+class TextRenderer;
+class TextGenerator
+{
+public:
+
+    void Initialize(const FontConfig& _config);
+
+    void Draw(const std::wstring& _text, const Vector2& _pos, const Vector4& _color = { 1,1,1,1 });
+
+    void Draw(const std::wstring& _text, const TextParam& _param);
+
+private:
+
+    TextRenderer* renderer_ = nullptr;
+
+    AtlasData* atlasData_ = {};
+
+};

--- a/Engine/Features/TextRenderer/TextParan.h
+++ b/Engine/Features/TextRenderer/TextParan.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Math/Vector/Vector2.h>
+#include <Math/Vector/Vector4.h>
+
+struct TextParam
+{
+    Vector2 scale = { 1.0f, 1.0f }; // スケール
+    float rotate = 0.0f; // 回転角度
+    Vector2 position; // 描画位置
+
+    bool useGradient = false; // グラデーションを使用するかどうか
+    Vector4 topColor = { 1, 1, 1, 1 }; // 上の色(グラデーション用)
+    Vector4 bottomColor = { 0, 0, 0, 1 }; // 下の色(グラデーション用)
+
+    Vector2 pivot = { 0.5f, 0.5f }; // ピボット位置
+
+    bool  useOutline = false; // アウトラインを使用するかどうか
+    Vector4 outlineColor = { 0, 0, 0, 1 }; // アウトラインの色
+    float outlineScale = 0.03f; // アウトラインの太さ
+
+    TextParam& SetScale(const Vector2& _scale) { scale = _scale; return *this; }
+    TextParam& SetRotate(float _rotate) { rotate = _rotate; return *this; }
+    TextParam& SetPosition(const Vector2& _pos) { position = _pos; return *this; }
+    TextParam& SetColor(const Vector4& _color) { topColor = _color; bottomColor = _color; useGradient = false; return *this; }
+    TextParam& SetGradientColor(const Vector4& _topColor, const Vector4& _bottomColor) { topColor = _topColor; bottomColor = _bottomColor; useGradient = true; return *this; }
+    TextParam& SetPivot(const Vector2& _piv) { pivot = _piv; return *this; }
+    TextParam& SetOutline(const Vector4& _outlineColor = { 0, 0, 0, 1 }, float _outlineScale = 0.03f)
+    {
+        useOutline = true;
+        outlineColor = _outlineColor;
+        outlineScale = _outlineScale;
+        return *this;
+    }
+};

--- a/Engine/Features/TextRenderer/TextRenderer.cpp
+++ b/Engine/Features/TextRenderer/TextRenderer.cpp
@@ -14,7 +14,7 @@ TextRenderer* TextRenderer::GetInstance()
     return &instance;
 }
 
-void TextRenderer::Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* _cmdList, const Config& _config, const Vector2& _windowSize)
+void TextRenderer::Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* _cmdList,  const Vector2& _windowSize)
 {
     if (!_device || !_cmdList)
         return;
@@ -22,22 +22,10 @@ void TextRenderer::Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* 
     device_ = _device;
     cmdList_ = _cmdList;
 
-    atlasSize_.x = _config.atlasSize.x;
-    atlasSize_.y = _config.atlasSize.y;
-
-    fontSize_ = _config.fontSize;
-
     windowSize_ = _windowSize;
 
     maxCharacters_ = 1500;
     maxVertices_ = 6 * maxCharacters_ ;// 1500文字分の頂点を確保
-
-
-    atlasData_.resize(static_cast<size_t>(atlasSize_.x * atlasSize_.y) ,0);
-    currentX_ = 0;
-    currentY_ = 0;
-    maxY_ = 0;
-    atlasNeedsUpdate_ = false;
 
     auto psoMana = PSOManager::GetInstance();
     // パイプラインステートオブジェクトの取得
@@ -55,109 +43,65 @@ void TextRenderer::Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* 
         assert(false && "TextRenderer: RootSignature not found. Please initialize PSOManager.");
         return;
     }
-
-
-    // フォント読み込み
-    LoadFont(_config.fontFilePath, _config.fontSize);
-
-    // フォントテクスチャの作成
-    CreateFontTexture();
-
-    // 頂点バッファの作成
-    CreateVertexBuffer();
-
-    // アフィン変換行列のバッファを作成
-    CreateMatrixBuffer();
-
-    // 投影行列のバッファを作成
     CreateProjectionMatrixBuffer();
-
-    // よく使う文字を事前生成
-    PreloadCommonCharacters();
-
-    if (atlasNeedsUpdate_)
-    {
-        UpdateFontTexture();
-        atlasNeedsUpdate_ = false;
-    }
-
 }
 
 void TextRenderer::Finalize()
 {
-    // テクスチャリソース解放
-    if (fontTexture_)
-    {
-        fontTexture_.Reset();
-    }
-
-    // 頂点バッファ解放
-    if (vertexBuffer_)
-    {
-        vertexBuffer_.Reset();
-    }
-
-    // メンバ変数をリセット
-    glyphs_.clear();
-    vertices_.clear();
-    fontBuffer_.clear();
-    atlasData_.clear();
-    affineMatrices_.clear();
 
     device_ = nullptr;
     cmdList_ = nullptr;
-    textureIndex_ = UINT32_MAX;
 }
 
 void TextRenderer::BeginFrame()
 {
-    // 頂点配列をクリア
-    vertices_.clear();
-    affineMatrices_.clear();
-
-    // フォントアトラスが更新されている場合はテクスチャを更新
-    if (atlasNeedsUpdate_)
+    for (auto& [textureindex, res] : resourceDataGroups_)
     {
-        UpdateFontTexture();
-        atlasNeedsUpdate_ = false;
+        // 頂点配列をクリア
+        res->vertices_.clear();
+        res->affineMatrices_.clear();
     }
 }
 
 void TextRenderer::EndFrame()
 {
-    if (vertices_.empty())
+    for (auto& [textureindex, res] : resourceDataGroups_)
     {
-        return;  // 描画するものがない
+        if (res->vertices_.empty())
+            continue;
+
+        // 頂点データをGPUに転送
+        UploadVertexData(res.get());
+        // アフィン変換行列をGPUに転送
+        UploadMatrixData(res.get());
+        // 描画コマンド実行
+        RenderText(res.get());
     }
-
-    // 頂点データをGPUに転送
-    UploadVertexData();
-    // アフィン変換行列をGPUに転送
-    UploadMatrixData();
-    // 描画コマンド実行
-    RenderText();
 }
 
-void TextRenderer::DrawText(const std::wstring& _text, const Vector2& _pos, const Vector4& _color)
+void TextRenderer::DrawText(const std::wstring& _text, AtlasData* _atlas, const Vector2& _pos, const Vector4& _color)
 {
-    DrawText(_text, _pos, { 1.0f, 1.0f }, 0.0f, { 0.5f, 0.5f }, _color, _color);
+    auto res = EnsureAtlasResources(_atlas);
+    DrawText(_text, _pos, { 1.0f, 1.0f }, 0.0f, { 0.5f, 0.5f }, _color, _color, res);
 }
 
-void TextRenderer::DrawText(const std::wstring& _text, const TextParam& _param)
+void TextRenderer::DrawText(const std::wstring& _text, AtlasData* _atlas, const TextParam& _param)
 {
+    auto res = EnsureAtlasResources(_atlas);
+
     if (_param.useOutline)
     {
         if (_param.useGradient)
-            DrawTextWithOutline(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.bottomColor, _param.outlineColor, _param.outlineScale);
+            DrawTextWithOutline(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.bottomColor, _param.outlineColor, _param.outlineScale, res);
         else
-            DrawTextWithOutline(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.topColor, _param.outlineColor, _param.outlineScale);
+            DrawTextWithOutline(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.topColor, _param.outlineColor, _param.outlineScale, res);
     }
     else
     {
         if (_param.useGradient)
-            DrawText(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.bottomColor);
+            DrawText(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.bottomColor, res);
         else
-            DrawText(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.topColor);
+            DrawText(_text, _param.position, _param.scale, _param.rotate, _param.pivot, _param.topColor, _param.topColor, res);
     }
 }
 
@@ -168,15 +112,20 @@ void TextRenderer::DrawText(
     float _rotate,
     const Vector2& _piv,
     const Vector4& _topColor,
-    const Vector4& _bottomColor)
+    const Vector4& _bottomColor,
+    ResourceDataGroup* _res)
 {
     if (_text.empty()) return;
 
     float currentX = 0;
     float currentY = 0;
 
+    AtlasData* atlas = _res->atlasData_;
+    float fontSize = atlas->GetFontSize();
+    float fontAscent = atlas->GetFontAscent();
+
     Vector2 anchor = _piv;
-    Vector2 stringArea = GetStringAreaSize(_text, _scale);
+    Vector2 stringArea = atlas->GetStringAreaSize(_text, _scale);
     Vector2 pivot = { stringArea.x * anchor.x, stringArea.y * anchor.y };
 
 
@@ -184,6 +133,7 @@ void TextRenderer::DrawText(
     Vector3 rotate3D = { 0.0f, 0.0f, _rotate };
     Vector3 translate3D = { _pos.x, _pos.y, 0.0f };
     Matrix4x4 transformMatrix = MakeAffineMatrix(scale3D, rotate3D, translate3D);
+
 
     for (size_t i = 0; i < _text.length(); ++i)
     {
@@ -193,19 +143,19 @@ void TextRenderer::DrawText(
         if (character == L'\n')
         {
             currentX = 0;
-            currentY += fontSize_;
+            currentY += fontSize;
             continue;
         }
 
         // スペース処理
         if (character == L' ')
         {
-            currentX += fontSize_ * 0.3f;  // スペース幅
+            currentX += fontSize * 0.3f;  // スペース幅
             continue;
         }
 
         // グリフ情報取得
-        GlyphInfo glyph = GetGlyph(character);
+        GlyphInfo glyph = atlas->GetGlyph(character);
         if (!glyph.isValid)
         {
             continue;
@@ -213,7 +163,7 @@ void TextRenderer::DrawText(
 
         // 文字の描画位置計算
         float glyphX = (currentX + glyph.bearingX) * _scale.x - pivot.x;
-        float baseline = currentY + fontAscent_;
+        float baseline = currentY + fontAscent;
         float glyphY = (baseline + glyph.bearingY) * _scale.y - pivot.y;
         float glyphW = glyph.width * _scale.x;
         float glyphH = glyph.height * _scale.y;
@@ -235,14 +185,14 @@ void TextRenderer::DrawText(
         // 頂点配列に追加
         for (int j = 0; j < 6; ++j)
         {
-            if (vertices_.size() < maxVertices_)
+            if (_res->vertices_.size() < maxVertices_)
             {
-                vertices_.push_back(quad[j]);
+                _res->vertices_.push_back(quad[j]);
             }
         }
 
         // アフィン変換行列を設定
-        affineMatrices_.push_back(transformMatrix);
+        _res->affineMatrices_.push_back(transformMatrix);
 
         // 次の文字位置に移動
         currentX += glyph.advance;
@@ -257,7 +207,8 @@ void TextRenderer::DrawTextWithOutline(const std::wstring& _text,
     const Vector4& _topColor,
     const Vector4& _bottomColor,
     const Vector4& _outlineColor,
-    float _outlineThickness)
+    float _outlineThickness,
+    ResourceDataGroup* _res)
 {
     if (_text.empty()) return;
 
@@ -267,7 +218,12 @@ void TextRenderer::DrawTextWithOutline(const std::wstring& _text,
                {-1, -1}, {-1, 1}, {1, -1}, {1, 1}
     };
 
-    float offsetPx = fontSize_ * _outlineThickness;
+
+    AtlasData* atlas = _res->atlasData_;
+    float fontSize = atlas->GetFontSize();
+    float fontAscent = atlas->GetFontAscent();
+
+    float offsetPx = fontSize * _outlineThickness;
 
     for (int i = 0; i < 8; ++i)
     {
@@ -277,14 +233,14 @@ void TextRenderer::DrawTextWithOutline(const std::wstring& _text,
         };
 
         // アウトライン色で本関数を再帰的に呼び出す（本体色でなく、単色）
-        DrawText(_text, offsetPos, _scale, _rotate, _piv, _outlineColor, _outlineColor);
+        DrawText(_text, offsetPos, _scale, _rotate, _piv, _outlineColor, _outlineColor, _res);
     }
 
     float currentX = 0;
     float currentY = 0;
 
     Vector2 anchor = _piv;
-    Vector2 stringArea = GetStringAreaSize(_text, _scale);
+    Vector2 stringArea = atlas->GetStringAreaSize(_text, _scale);
     Vector2 pivot = { stringArea.x * anchor.x, stringArea.y * anchor.y };
 
 
@@ -301,19 +257,19 @@ void TextRenderer::DrawTextWithOutline(const std::wstring& _text,
         if (character == L'\n')
         {
             currentX = 0;
-            currentY += fontSize_;
+            currentY += fontSize;
             continue;
         }
 
         // スペース処理
         if (character == L' ')
         {
-            currentX += fontSize_ * 0.3f;  // スペース幅
+            currentX += fontSize * 0.3f;  // スペース幅
             continue;
         }
 
         // グリフ情報取得
-        GlyphInfo glyph = GetGlyph(character);
+        GlyphInfo glyph = atlas->GetGlyph(character);
         if (!glyph.isValid)
         {
             continue;
@@ -321,7 +277,7 @@ void TextRenderer::DrawTextWithOutline(const std::wstring& _text,
 
         // 文字の描画位置計算
         float glyphX = (currentX + glyph.bearingX) * _scale.x - pivot.x;
-        float baseline = currentY + fontAscent_;
+        float baseline = currentY + fontAscent;
         float glyphY = (baseline + glyph.bearingY) * _scale.y - pivot.y;
         float glyphW = glyph.width * _scale.x;
         float glyphH = glyph.height * _scale.y;
@@ -343,127 +299,81 @@ void TextRenderer::DrawTextWithOutline(const std::wstring& _text,
         // 頂点配列に追加
         for (int j = 0; j < 6; ++j)
         {
-            if (vertices_.size() < maxVertices_)
+            if (_res->vertices_.size() < maxVertices_)
             {
-                vertices_.push_back(quad[j]);
+                _res->vertices_.push_back(quad[j]);
             }
         }
 
         // アフィン変換行列を設定
-        affineMatrices_.push_back(transformMatrix);
+        _res->affineMatrices_.push_back(transformMatrix);
 
         // 次の文字位置に移動
         currentX += glyph.advance;
     }
 }
 
-Vector2 TextRenderer::GetCenterPosition(const std::wstring& _text, const Vector2& _pos, const Vector2& _scale, const Vector2& _piv)
-{
-    Vector2 stringArea = GetStringAreaSize(_text, _scale);
-    Vector2 pivot = { stringArea.x * _piv.x, stringArea.y * _piv.y };
-    return _pos + pivot;
-}
 
-
-void TextRenderer::LoadFont(const std::string& _fontFilePath, float _fontSize)
+TextRenderer::ResourceDataGroup* TextRenderer::EnsureAtlasResources(AtlasData* _atlas)
 {
-    std::ifstream file(_fontFilePath, std::ios::binary);
-    if (!file.is_open())
+    if (!_atlas)
+        return nullptr;
+
+    int32_t atlasTextureIndex = _atlas->GetFontTextureIndex();
+    auto it = resourceDataGroups_.find(atlasTextureIndex);
+    if (it != resourceDataGroups_.end())
     {
-        assert("Failed to open font file");
-        return;
+        return it->second.get(); // 既存のリソースグループを返す
     }
 
-    file.seekg(0, std::ios::end);
-    size_t fileSize = static_cast<size_t>(file.tellg());
-    file.seekg(0, std::ios::beg);
+    // 新しいアトラスデータグループを作成
+    auto resourceDataGroup = std::make_unique<ResourceDataGroup>();
 
-    fontBuffer_.resize(fileSize);
-    file.read(reinterpret_cast<char*>(fontBuffer_.data()), fileSize);
-    file.close();
+    // 頂点バッファの作成
+    CreateVertexBuffer(resourceDataGroup.get());
 
-    if (!stbtt_InitFont(&fontInfo_, fontBuffer_.data(), 0))
-    {
-        assert("Failed to initialize font");
-        return;
-    }
+    // アフィン変換行列のバッファを作成
+    CreateMatrixBuffer(resourceDataGroup.get());
 
-    scale_ = stbtt_ScaleForPixelHeight(&fontInfo_, _fontSize);
+    // アトラスデータを設定
+    resourceDataGroup->atlasData_ = _atlas;
+    resourceDataGroup->textureIndex_ = atlasTextureIndex;
 
-    int ascent, descent, lineGap;
-    stbtt_GetFontVMetrics(&fontInfo_, &ascent, &descent, &lineGap);
+    resourceDataGroups_.emplace(atlasTextureIndex, std::move(resourceDataGroup));
 
-    // スケールを掛けてfloat型に変換
-    fontAscent_ = ascent * scale_;
-    fontDescent_ = descent * scale_;
-    fontLineGap_ = lineGap * scale_;
+
+    return resourceDataGroups_[atlasTextureIndex].get();
 
 }
 
-void TextRenderer::CreateFontTexture()
+void TextRenderer::CreateVertexBuffer(ResourceDataGroup* _res)
 {
-    D3D12_RESOURCE_DESC texDesc = {};
-    texDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-    texDesc.Width = static_cast<UINT64>(atlasSize_.x);
-    texDesc.Height = static_cast<UINT>(atlasSize_.y);
-    texDesc.DepthOrArraySize = 1;
-    texDesc.MipLevels = 1;
-    texDesc.Format = DXGI_FORMAT_R8_UNORM;
-    texDesc.SampleDesc.Count = 1;
-    texDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-    texDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+    _res->vertexBuffer_ = DXCommon::GetInstance()->CreateBufferResource(static_cast<uint32_t>(sizeof(TextVertex) * maxVertices_));
 
-    D3D12_HEAP_PROPERTIES heapProps = {};
-    heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
-
-
-    HRESULT hr = device_->CreateCommittedResource(
-        &heapProps, D3D12_HEAP_FLAG_NONE, &texDesc,
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
-        IID_PPV_ARGS(&fontTexture_));
-
-    if (FAILED(hr))
-    {
-        assert("Failed to create font texture resource");
-        return;
-    }
-
-    textureIndex_ = SRVManager::GetInstance()->Allocate();
-    SRVManager::GetInstance()->CreateSRVForTextrue2D(textureIndex_, fontTexture_.Get(), DXGI_FORMAT_R8_UNORM, 1);
-
-    size_t uploadBufferSize = static_cast<size_t>(atlasSize_.x * atlasSize_.y);
-
-    uploadBuffer_ = DXCommon::GetInstance()->CreateBufferResource(static_cast<uint32_t>(uploadBufferSize));
-}
-
-void TextRenderer::CreateVertexBuffer()
-{
-    vertexBuffer_ = DXCommon::GetInstance()->CreateBufferResource(static_cast<uint32_t>(sizeof(TextVertex) * maxVertices_));
-
-    if (!vertexBuffer_)
+    if (!_res->vertexBuffer_)
     {
         assert("Failed to create vertex buffer resource");
         return;
     }
     // 頂点バッファビューの設定
-    vbv_.BufferLocation = vertexBuffer_->GetGPUVirtualAddress();
-    vbv_.StrideInBytes = sizeof(TextVertex);
+    _res->vbv_.BufferLocation = _res->vertexBuffer_->GetGPUVirtualAddress();
+    _res->vbv_.StrideInBytes = sizeof(TextVertex);
 
 }
 
-void TextRenderer::CreateMatrixBuffer()
+void TextRenderer::CreateMatrixBuffer(ResourceDataGroup* _res)
 {
     // マトリックスバッファの作成
-    matrixBuffer_ = DXCommon::GetInstance()->CreateBufferResource(static_cast<uint32_t>(sizeof(Matrix4x4) * maxCharacters_));
-    if (!matrixBuffer_)
+    _res->matrixBuffer_ = DXCommon::GetInstance()->CreateBufferResource(static_cast<uint32_t>(sizeof(Matrix4x4) * maxCharacters_));
+    if (!_res->matrixBuffer_)
     {
         assert("Failed to create matrix buffer resource");
         return;
     }
 
-    affrinMatSRVIndex_ = SRVManager::GetInstance()->Allocate();
+    _res->affrinMatSRVIndex_ = SRVManager::GetInstance()->Allocate();
 
-    SRVManager::GetInstance()->CreateSRVForStructureBuffer(affrinMatSRVIndex_, matrixBuffer_.Get(), static_cast<UINT>(maxCharacters_), sizeof(Matrix4x4));
+    SRVManager::GetInstance()->CreateSRVForStructureBuffer(_res->affrinMatSRVIndex_, _res->matrixBuffer_.Get(), static_cast<UINT>(maxCharacters_), sizeof(Matrix4x4));
 }
 
 void TextRenderer::CreateProjectionMatrixBuffer()
@@ -480,240 +390,55 @@ void TextRenderer::CreateProjectionMatrixBuffer()
     *projectionMatrix_ = MakeOrthographicMatrix(0, 0, windowSize_.x, windowSize_.y, -1.0f, 1.0f);
 }
 
-void TextRenderer::UpdateFontTexture()
+void TextRenderer::UploadVertexData(ResourceDataGroup* _res)
 {
-    // アップロード用の中間バッファ作成
-    size_t uploadBufferSize = static_cast<size_t>(atlasSize_.x * atlasSize_.y);
-
-
-    // データをアップロードバッファにコピー
-    void* mappedData;
-    HRESULT hr = uploadBuffer_->Map(0, nullptr, &mappedData);
-    if (SUCCEEDED(hr))
-    {
-        memcpy(mappedData, atlasData_.data(), uploadBufferSize);
-        uploadBuffer_->Unmap(0, nullptr);
-    }
-
-    // テクスチャコピー情報設定
-    D3D12_TEXTURE_COPY_LOCATION srcLocation = {};
-    srcLocation.pResource = uploadBuffer_.Get();
-    srcLocation.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
-    srcLocation.PlacedFootprint.Offset = 0;
-    srcLocation.PlacedFootprint.Footprint.Format = DXGI_FORMAT_R8_UNORM;
-    srcLocation.PlacedFootprint.Footprint.Width = static_cast<UINT>(atlasSize_.x);
-    srcLocation.PlacedFootprint.Footprint.Height = static_cast<UINT>(atlasSize_.y);
-    srcLocation.PlacedFootprint.Footprint.Depth = 1;
-    srcLocation.PlacedFootprint.Footprint.RowPitch = static_cast<UINT>(atlasSize_.x);
-
-    D3D12_TEXTURE_COPY_LOCATION dstLocation = {};
-    dstLocation.pResource = fontTexture_.Get();
-    dstLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
-    dstLocation.SubresourceIndex = 0;
-
-    // リソース状態遷移
-    D3D12_RESOURCE_BARRIER barrier = {};
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    barrier.Transition.pResource = fontTexture_.Get();
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
-    barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-    cmdList_->ResourceBarrier(1, &barrier);
-
-    // テクスチャコピー実行
-    cmdList_->CopyTextureRegion(&dstLocation, 0, 0, 0, &srcLocation, nullptr);
-
-    // リソース状態を戻す
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    cmdList_->ResourceBarrier(1, &barrier);
-}
-
-void TextRenderer::UploadVertexData()
-{
-    if (vertices_.empty()) return;
+    if (_res->vertices_.empty()) return;
 
     // 頂点バッファにデータをマップしてコピー
     void* mappedData;
-    HRESULT hr = vertexBuffer_->Map(0, nullptr, &mappedData);
+    HRESULT hr = _res->vertexBuffer_->Map(0, nullptr, &mappedData);
     if (SUCCEEDED(hr))
     {
-        size_t dataSize = sizeof(TextVertex) * vertices_.size();
-        memcpy(mappedData, vertices_.data(), dataSize);
-        vertexBuffer_->Unmap(0, nullptr);
+        size_t dataSize = sizeof(TextVertex) * _res->vertices_.size();
+        memcpy(mappedData, _res->vertices_.data(), dataSize);
+        _res->vertexBuffer_->Unmap(0, nullptr);
     }
 }
 
-void TextRenderer::UploadMatrixData()
+void TextRenderer::UploadMatrixData(ResourceDataGroup* _res)
 {
-    if (affineMatrices_.empty()) return;
+    if (_res->affineMatrices_.empty()) return;
     // アフィン変換行列をマップしてコピー
     void* mappedData;
-    HRESULT hr = matrixBuffer_->Map(0, nullptr, &mappedData);
+    HRESULT hr = _res->matrixBuffer_->Map(0, nullptr, &mappedData);
     if (SUCCEEDED(hr))
     {
-        size_t dataSize = sizeof(Matrix4x4) * affineMatrices_.size();
-        memcpy(mappedData, affineMatrices_.data(), dataSize);
-        matrixBuffer_->Unmap(0, nullptr);
+        size_t dataSize = sizeof(Matrix4x4) * _res->affineMatrices_.size();
+        memcpy(mappedData, _res->affineMatrices_.data(), dataSize);
+        _res->matrixBuffer_->Unmap(0, nullptr);
     }
 }
 
-void TextRenderer::RenderText()
+void TextRenderer::RenderText(ResourceDataGroup* _res)
 {
-    if (vertices_.empty()) return;
+    if (_res->vertices_.empty()) return;
 
     cmdList_->SetPipelineState(pso_);
     cmdList_->SetGraphicsRootSignature(rootSignature_);
 
     // 頂点バッファビュー設定
-    vbv_.SizeInBytes = static_cast<UINT>(sizeof(TextVertex) * vertices_.size());
+    _res->vbv_.SizeInBytes = static_cast<UINT>(sizeof(TextVertex) * _res->vertices_.size());
 
     // 描画コマンド
-    cmdList_->IASetVertexBuffers(0, 1, &vbv_);
+    cmdList_->IASetVertexBuffers(0, 1, &_res->vbv_);
     cmdList_->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     cmdList_->SetGraphicsRootConstantBufferView(0, projectionMatrixBuffer_->GetGPUVirtualAddress());
-    cmdList_->SetGraphicsRootDescriptorTable(1, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(textureIndex_));
-    cmdList_->SetGraphicsRootDescriptorTable(2, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(affrinMatSRVIndex_));
+    cmdList_->SetGraphicsRootDescriptorTable(1, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(_res->textureIndex_));
+    cmdList_->SetGraphicsRootDescriptorTable(2, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(_res->affrinMatSRVIndex_));
 
 
     // 描画実行
-    UINT vertexCount = static_cast<UINT>(vertices_.size());
+    UINT vertexCount = static_cast<UINT>(_res->vertices_.size());
     cmdList_->DrawInstanced(vertexCount, 1, 0, 0);
-}
-
-Vector2 TextRenderer::GetStringAreaSize(const std::wstring& _text, const Vector2& _scale)
-{
-    Vector2 area = {};
-    if (_text.empty()) return area;
-
-    float currentX = 0.0f;
-    float currentY = 0.0f;
-    float maxWidth = 0.0f;
-    float lineHeight = fontSize_ * _scale.y;
-
-    for (size_t i = 0; i < _text.length(); ++i)
-    {
-        wchar_t character = _text[i];
-        // 改行処理
-        if (character == L'\n')
-        {
-            currentX = 0.0f;
-            currentY += lineHeight;
-            maxWidth = (std::max)(maxWidth, currentX);
-
-            continue;
-        }
-        // スペース処理
-        if (character == L' ')
-        {
-            currentX += fontSize_ * 0.3f * _scale.x;  // スペース幅
-            continue;
-        }
-        // グリフ情報取得
-        GlyphInfo glyph = GetGlyph(character);
-        if (!glyph.isValid)
-        {
-            continue;
-        }
-        // 文字の幅を加算
-        currentX += glyph.advance * _scale.x;
-    }
-    area.x = currentX;
-    area.y = currentY + lineHeight;
-
-    if (area.x < 0.0f) area.x = 0.0f;
-    if (area.y < 0.0f) area.y = 0.0f;
-
-    return area;
-
-}
-
-void TextRenderer::PreloadCommonCharacters()
-{
-    for (char c = 32; c < 127; c++)
-    {
-        GetGlyph(static_cast<wchar_t>(c));
-    }
-
-}
-
-TextRenderer::GlyphInfo TextRenderer::GetGlyph(wchar_t _character)
-{
-    auto it = glyphs_.find(_character);
-    if (it != glyphs_.end())
-    {
-        return it->second;
-    }
-    return GenerateGlyph(_character);
-}
-
-TextRenderer::GlyphInfo TextRenderer::GenerateGlyph(wchar_t _character)
-{
-    int width, height, xOffset, yOffset;
-
-    unsigned char* bitmap = stbtt_GetCodepointBitmap(
-        &fontInfo_, 0, scale_, _character,
-        &width, &height, &xOffset, &yOffset);
-
-    GlyphInfo glyph = {};
-
-    if (!bitmap)
-    {
-        // 文字が見つからない場合は□を表示
-        if (_character != L'□')
-        {
-            return GetGlyph(L'□');
-        }
-        glyph.isValid = false;
-        return glyph;
-    }
-
-    // アトラスに配置
-    if (currentX_ + width >= atlasSize_.x)
-    {
-        currentX_ = 0;
-        currentY_ += maxY_;
-        maxY_ = 0;
-    }
-
-    // ビットマップをアトラスにコピー
-    for (int y = 0; y < height; y++)
-    {
-        for (int x = 0; x < width; x++)
-        {
-            int srcIndex = y * width + x;
-            int dstIndex = static_cast<int>(currentY_ + y) * static_cast<int>(atlasSize_.x)+ static_cast<int>(currentX_ + x);
-            if (dstIndex < static_cast<int>(atlasData_.size())) {
-                atlasData_[dstIndex] = bitmap[srcIndex];
-            }
-        }
-    }
-
-    // グリフ情報を設定
-    glyph.u0 = static_cast<float>(currentX_) / atlasSize_.x;
-    glyph.v0 = static_cast<float>(currentY_) / atlasSize_.y;
-    glyph.u1 = static_cast<float>(currentX_ + width) / atlasSize_.x;
-    glyph.v1 = static_cast<float>(currentY_ + height) / atlasSize_.y;
-    glyph.width = static_cast<float>(width);
-    glyph.height = static_cast<float>(height);
-    glyph.bearingX = static_cast<float>(xOffset);
-    glyph.bearingY = static_cast<float>(yOffset);
-    glyph.isValid = true;
-
-    // アドバンス幅を取得
-    int advanceWidth, leftSideBearing;
-    stbtt_GetCodepointHMetrics(&fontInfo_, _character, &advanceWidth, &leftSideBearing);
-    glyph.advance = advanceWidth * scale_;
-
-    // 位置を更新
-    currentX_ += width + 1;
-    maxY_ = (std::max)(maxY_, height + 1);
-
-    // キャッシュに保存
-    glyphs_[_character] = glyph;
-    atlasNeedsUpdate_ = true;
-
-    stbtt_FreeBitmap(bitmap, nullptr);
-    return glyph;
 }

--- a/Engine/Features/TextRenderer/TextRenderer.h
+++ b/Engine/Features/TextRenderer/TextRenderer.h
@@ -2,6 +2,9 @@
 
 #include <Externals/stb/stb_truetype.h>
 
+#include <Features/TextRenderer/AtlasData.h>
+#include <Features/TextRenderer/TextParan.h>
+
 #include <Math/Vector/Vector2.h>
 #include <Math/Vector/Vector4.h>
 #include <Math/Matrix/Matrix4x4.h>
@@ -20,79 +23,55 @@
 #undef DrawText
 #endif // DrawText
 
-struct TextParam
-{
-    Vector2 scale = { 1.0f, 1.0f }; // スケール
-    float rotate = 0.0f; // 回転角度
-    Vector2 position; // 描画位置
-
-    bool useGradient = false; // グラデーションを使用するかどうか
-    Vector4 topColor = { 1, 1, 1, 1 }; // 上の色(グラデーション用)
-    Vector4 bottomColor = { 0, 0, 0, 1 }; // 下の色(グラデーション用)
-
-    Vector2 pivot = { 0.5f, 0.5f }; // ピボット位置
-
-    bool  useOutline = false; // アウトラインを使用するかどうか
-    Vector4 outlineColor = { 0, 0, 0, 1 }; // アウトラインの色
-    float outlineScale = 0.03f; // アウトラインの太さ
-
-    TextParam& SetScale(const Vector2& _scale) { scale = _scale; return *this; }
-    TextParam& SetRotate(float _rotate) { rotate = _rotate; return *this; }
-    TextParam& SetPosition(const Vector2& _pos) { position = _pos; return *this; }
-    TextParam& SetColor(const Vector4& _color) { topColor = _color; bottomColor = _color; useGradient = false; return *this; }
-    TextParam& SetGradientColor(const Vector4& _topColor, const Vector4& _bottomColor) { topColor = _topColor; bottomColor = _bottomColor; useGradient = true; return *this; }
-    TextParam& SetPivot(const Vector2& _piv) { pivot = _piv; return *this; }
-    TextParam& SetOutline(const Vector4& _outlineColor = { 0, 0, 0, 1 }, float _outlineScale = 0.03f)
-    {
-        useOutline = true;
-        outlineColor = _outlineColor;
-        outlineScale = _outlineScale;
-        return *this;
-    }
-};
-
 class TextRenderer
 {
 public:
     static TextRenderer* GetInstance();
 
-
-public:
-
-    struct Config
-    {
-        Vector2 atlasSize = { 4096,4096 }; // アトラスの幅
-        float fontSize = 32.0f; // フォントサイズ
-        std::string fontFilePath = "Resources/Fonts/NotoSansJP-Regular.ttf"; // フォントファイルのパス
-    };
-
-private:
-
-    struct GlyphInfo
-    {
-        float u0, v0, u1, v1;      // UV座標
-        float width, height;        // サイズ
-        float bearingX, bearingY;   // オフセット
-        float advance;              // 次の文字までの距離
-        bool isValid = false;
-    };
 public:
 
 
-    void Initialize(ID3D12Device* _device,ID3D12GraphicsCommandList* _cmdList, const Config& _config, const Vector2& _windowSize = { 1280,720 });
+    void Initialize(ID3D12Device* _device, ID3D12GraphicsCommandList* _cmdList, const Vector2& _windowSize = { 1280,720 });
     void Finalize();
 
     void BeginFrame();
     void EndFrame();
 
-    void DrawText(const std::wstring& _text, const Vector2& _pos, const Vector4& _color = { 1,1,1,1 });
+    void DrawText(const std::wstring& _text, AtlasData* _atlas, const Vector2& _pos, const Vector4& _color = { 1,1,1,1 });
 
-    void DrawText(const std::wstring& _text, const TextParam& _param);
+    void DrawText(const std::wstring& _text, AtlasData* _atlas, const TextParam& _param);
 
 
 
 private:
-    void DrawText(const std::wstring& _text, const Vector2& _pos, const Vector2& _scale, float _rotate, const Vector2& _piv, const Vector4& _topColor, const Vector4& _bottomColor);
+
+    struct TextVertex
+    {
+        Vector4 position = { 0,0,0,1 }; // 頂点の位置
+        Vector2 texCoord = { 0,0 }; // テクスチャ座標
+        Vector4 color = { 1,1,1,1 }; // 頂点の色
+    };
+
+    struct ResourceDataGroup
+    {
+        // 描画用
+        std::vector<TextVertex> vertices_;
+
+        D3D12_VERTEX_BUFFER_VIEW vbv_; // 頂点バッファビュー
+        Microsoft::WRL::ComPtr<ID3D12Resource> vertexBuffer_; // 頂点バッファ
+
+        std::vector<Matrix4x4> affineMatrices_; // アフィン変換行列
+
+        Microsoft::WRL::ComPtr<ID3D12Resource> matrixBuffer_; // アフィン変換行列のバッファ
+        uint32_t affrinMatSRVIndex_ = UINT32_MAX; // アフィン変換行列のSRVインデックス
+
+        uint32_t textureIndex_ = UINT32_MAX; // テクスチャのSRVインデックス
+
+        AtlasData* atlasData_ = nullptr; // アトラスデータ
+    };
+
+private:
+    void DrawText(const std::wstring& _text, const Vector2& _pos, const Vector2& _scale, float _rotate, const Vector2& _piv, const Vector4& _topColor, const Vector4& _bottomColor, ResourceDataGroup* _res);
     void DrawTextWithOutline(
         const std::wstring& _text,
         const Vector2& _pos,
@@ -102,85 +81,38 @@ private:
         const Vector4& _topColor,
         const Vector4& _bottomColor,
         const Vector4& _outlineColor,
-        float _outlineThickness);
+        float _outlineThickness,
+        ResourceDataGroup* _res);
 
-    // 中心座標を求める ヘルパー関数
-    Vector2 GetCenterPosition(const std::wstring& _text, const Vector2& _pos, const Vector2& _scale, const Vector2& _piv);
+    // アトラスデータを設定
+    ResourceDataGroup* EnsureAtlasResources(AtlasData* _atlas);
 
-
-    void LoadFont(const std::string& _fontFilePath,float _fontSize);
-    void CreateFontTexture();
-    void CreateVertexBuffer();
-    void CreateMatrixBuffer();
+    void CreateVertexBuffer(ResourceDataGroup* _res);
+    void CreateMatrixBuffer(ResourceDataGroup* _res);
     void CreateProjectionMatrixBuffer();
 
 
-    void UpdateFontTexture();
-    void UploadVertexData();
-    void UploadMatrixData();
-    void RenderText();
-
-    Vector2 GetStringAreaSize(const std::wstring& _text, const Vector2& _scale);
-
-    void PreloadCommonCharacters();
-
-
-    GlyphInfo GetGlyph(wchar_t _character);
-    GlyphInfo GenerateGlyph(wchar_t _character);
+    void UploadVertexData(ResourceDataGroup* _res);
+    void UploadMatrixData(ResourceDataGroup* _res);
+    void RenderText(ResourceDataGroup* _res);
 
 private:
 
 
-    struct TextVertex
-    {
-        Vector4 position = {0,0,0,1}; // 頂点の位置
-        Vector2 texCoord = { 0,0 }; // テクスチャ座標
-        Vector4 color = { 1,1,1,1 }; // 頂点の色
-    };
 
     ID3D12PipelineState* pso_; // パイプラインステートオブジェクト
     ID3D12RootSignature* rootSignature_; // ルートシグネチャ
 
-    D3D12_VERTEX_BUFFER_VIEW vbv_; // 頂点バッファビュー
-
     ID3D12Device* device_; // D3D12デバイス
     ID3D12GraphicsCommandList* cmdList_; // コマンドリスト
-    Microsoft::WRL::ComPtr<ID3D12Resource> fontTexture_; // フォントテクスチャ
 
-    uint32_t textureIndex_; // テクスチャのインデックス
-    Microsoft::WRL::ComPtr<ID3D12Resource> vertexBuffer_; // 頂点バッファ
-
-    Microsoft::WRL::ComPtr<ID3D12Resource> uploadBuffer_;
-
-    stbtt_fontinfo fontInfo_; // フォント情報
-    std::vector<uint8_t> fontBuffer_; // フォントデータを格納するバッファ
-    float scale_;
-    float fontSize_;
-
-    // テクスチャアトラスの情報
-    std::vector<uint8_t> atlasData_; // テクスチャアトラスのバッファ
-    Vector2 atlasSize_; // アトラスのサイズ
-    int32_t currentX_; // 現在のX位置
-    int32_t currentY_; // 現在のY位置
-    int32_t maxY_; // アトラスの最大Y位置
-    std::unordered_map<wchar_t, GlyphInfo> glyphs_; // グリフ情報を格納するマップ
-    bool atlasNeedsUpdate_; // アトラスの更新が必要かどうか
-
-    float fontAscent_;
-    float fontDescent_;
-    float fontLineGap_;
-
-    // 描画用
-    std::vector<TextVertex> vertices_;
     size_t maxVertices_;
-
-    std::vector<Matrix4x4> affineMatrices_; // アフィン変換行列
     size_t maxCharacters_ = 1500; // 最大文字数
-    Microsoft::WRL::ComPtr<ID3D12Resource> matrixBuffer_; // アフィン変換行列のバッファ
-    uint32_t affrinMatSRVIndex_ = UINT32_MAX; // アフィン変換行列のSRVインデックス
 
     Matrix4x4* projectionMatrix_; // 投影行列
     Microsoft::WRL::ComPtr<ID3D12Resource> projectionMatrixBuffer_; // 投影行列のバッファ
+
+    std::map<uint32_t, std::unique_ptr<ResourceDataGroup>> resourceDataGroups_; // リソースデータグループ
 
     Vector2 windowSize_;
 

--- a/Engine/Framework/Framework.cpp
+++ b/Engine/Framework/Framework.cpp
@@ -78,7 +78,13 @@ void Framework::Initialize(const std::wstring& _winTitle)
     gameTime_ = GameTime::GetInstance();
     gameTime_->Initialize();
 
+    fontCache_ = FontCache::GetInstance();
+    fontCache_->Initialize(dxCommon_->GetDevice(), dxCommon_->GetCommandList(),
+        Vector2(static_cast<float>(WinApp::kWindowWidth_), static_cast<float>(WinApp::kWindowHeight_)));
+
     textRenderer_ = TextRenderer::GetInstance();
+    textRenderer_->Initialize(dxCommon_->GetDevice(), dxCommon_->GetCommandList(),
+        Vector2(static_cast<float>(WinApp::kWindowWidth_), static_cast<float>(WinApp::kWindowHeight_)));
 
     collisionManager_ = CollisionManager::GetInstance();
 

--- a/Engine/Framework/Framework.h
+++ b/Engine/Framework/Framework.h
@@ -13,6 +13,8 @@
 #include <System/Audio/Audio.h>
 #include <System/Time/Time_MT.h>
 #include <Features/TextRenderer/TextRenderer.h>
+#include <Features/TextRenderer/FontCache.h>
+
 
 class Framework
 {
@@ -51,6 +53,7 @@ protected:
     GameTime*               gameTime_               = nullptr;//
     Audio* audio_ = nullptr;//
     TextRenderer* textRenderer_ = nullptr;//
+    FontCache* fontCache_ = nullptr;//
 
 
 

--- a/Engine/GameEngine.vcxproj
+++ b/Engine/GameEngine.vcxproj
@@ -215,7 +215,10 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClCompile Include="Features\SilhouetteDetection.cpp" />
     <ClCompile Include="Features\Sprite\Sprite.cpp" />
     <ClCompile Include="Features\Sprite\SpriteManager.cpp" />
+    <ClCompile Include="Features\TextRenderer\AtlasData.cpp" />
+    <ClCompile Include="Features\TextRenderer\FontCache.cpp" />
     <ClCompile Include="Features\TextRenderer\STBImplementation.cpp" />
+    <ClCompile Include="Features\TextRenderer\TextGenerator.cpp" />
     <ClCompile Include="Features\TextRenderer\TextRenderer.cpp" />
     <ClCompile Include="Features\UI\ButtonNavigator.cpp" />
     <ClCompile Include="Features\UI\UIBase.cpp" />
@@ -340,6 +343,10 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClInclude Include="Features\SilhouetteDetection.h" />
     <ClInclude Include="Features\Sprite\Sprite.h" />
     <ClInclude Include="Features\Sprite\SpriteManager.h" />
+    <ClInclude Include="Features\TextRenderer\AtlasData.h" />
+    <ClInclude Include="Features\TextRenderer\FontCache.h" />
+    <ClInclude Include="Features\TextRenderer\TextGenerator.h" />
+    <ClInclude Include="Features\TextRenderer\TextParan.h" />
     <ClInclude Include="Features\TextRenderer\TextRenderer.h" />
     <ClInclude Include="Features\UI\ButtonNavigator.h" />
     <ClInclude Include="Features\UI\UIBase.h" />

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -229,9 +229,6 @@
     <Filter Include="Features\LevelEditor\Loader">
       <UniqueIdentifier>{63f432ce-bc89-48fa-8545-82e8f5b69960}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Features\TextRenderring">
-      <UniqueIdentifier>{836eac1b-0b99-447c-bace-230d0eed60ca}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Utility\FileDialog">
       <UniqueIdentifier>{2837f622-517e-4658-8264-59f3d93a05fa}</UniqueIdentifier>
     </Filter>
@@ -249,6 +246,9 @@
     </Filter>
     <Filter Include="Features\Collision\SpatialHashGrid">
       <UniqueIdentifier>{8ccabc1c-898d-4356-9e85-abbf31094bee}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Features\Text">
+      <UniqueIdentifier>{836eac1b-0b99-447c-bace-230d0eed60ca}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -545,10 +545,10 @@
     </ClCompile>
     <ClCompile Include="LevelEditorLoader.cpp" />
     <ClCompile Include="Features\TextRenderer\TextRenderer.cpp">
-      <Filter>Features\TextRenderring</Filter>
+      <Filter>Features\Text</Filter>
     </ClCompile>
     <ClCompile Include="Features\TextRenderer\STBImplementation.cpp">
-      <Filter>Features\TextRenderring</Filter>
+      <Filter>Features\Text</Filter>
     </ClCompile>
     <ClCompile Include="Utility\FileDialog\FileDialog.cpp">
       <Filter>Utility\FileDialog</Filter>
@@ -576,6 +576,15 @@
     </ClCompile>
     <ClCompile Include="Features\Json\JsonSerializers.cpp">
       <Filter>Features\Json</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\TextRenderer\FontCache.cpp">
+      <Filter>Features\Text</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\TextRenderer\AtlasData.cpp">
+      <Filter>Features\Text</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\TextRenderer\TextGenerator.cpp">
+      <Filter>Features\Text</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -949,7 +958,7 @@
       <Filter>Features\LevelEditor\Loader</Filter>
     </ClInclude>
     <ClInclude Include="Features\TextRenderer\TextRenderer.h">
-      <Filter>Features\TextRenderring</Filter>
+      <Filter>Features\Text</Filter>
     </ClInclude>
     <ClInclude Include="Utility\FileDialog\FileDialog.h">
       <Filter>Utility\FileDialog</Filter>
@@ -974,6 +983,18 @@
     </ClInclude>
     <ClInclude Include="Features\Json\JsonSerializers.h">
       <Filter>Features\Json</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\TextRenderer\AtlasData.h">
+      <Filter>Features\Text</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\TextRenderer\FontCache.h">
+      <Filter>Features\Text</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\TextRenderer\TextGenerator.h">
+      <Filter>Features\Text</Filter>
+    </ClInclude>
+    <ClInclude Include="Features\TextRenderer\TextParan.h">
+      <Filter>Features\Text</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
新たに複数のクラスを作成
fontcache:ロードしたフォントをまとめて管理
atlasData:一つのフォントのデータ
TextGenerator:ユーザー使用 フォント設定保持
textrenderer:描画責任 バッチによる最適化

- `TextRenderer` クラスの `Initialize` メソッドから `Config` 構造体を削除し、`AtlasData` を使用するように変更。
- `TextRenderer` メソッドが `ResourceDataGroup` を引数に取り、リソース管理を強化。
- 新たに `FontCache` クラスを追加し、フォントデータのキャッシュ機能を実装。
- `AtlasData` クラスを作成し、フォントのテクスチャアトラスの管理を一元化。
- `TextGenerator` クラスを追加し、テキスト描画のインターフェースを簡素化。
- `TextParam` 構造体を追加し、描画時のパラメータ管理を強化。
- 不要なメソッドや構造体を削除し、コードのクリーンアップを実施。
- `GameEngine` プロジェクトに新しいファイルを追加し、フォント関連機能を強化。