### PR TITLE
テキスト描画システムの更新とUI調整

### DIFF
--- a/Sample/Resources/Shader/Object3d.PS.hlsl
+++ b/Sample/Resources/Shader/Object3d.PS.hlsl
@@ -107,7 +107,7 @@ PixelShaderOutput main(VertexShaderOutput _input)
 {
     PixelShaderOutput output;
     output.color = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    float4 textureColor = deffuseColor;
+    float4 textureColor = deffuseColor * materialColor;
 
     if (hasTexture != 0)
     {

--- a/Sample/SampleFramework.cpp
+++ b/Sample/SampleFramework.cpp
@@ -30,12 +30,6 @@ void SampleFramework::Initialize(const std::wstring& _winTitle)
 
     sceneManager_->SetSceneFactory(new SceneFactory());
     particleManager_->SetModifierFactory(new ParticleModifierFactory());
-    textRenderer_->Initialize(
-        dxCommon_->GetDevice(),
-        dxCommon_->GetCommandList(),
-        TextRenderer::Config(),
-         WinApp::kWindowSize_ );
-
 
     Vector2 fieldSize = { 100.0f, 100.0f };
     Vector2 leftBottom = { -50.0f, -50.0f };
@@ -84,6 +78,8 @@ void SampleFramework::Draw()
 
     lineDrawer_->Draw();
     //=============================
+
+    textRenderer_->EndFrame();
 
     currentTex_ = "default";
 

--- a/Sample/deveScene/DeveScene.cpp
+++ b/Sample/deveScene/DeveScene.cpp
@@ -152,12 +152,11 @@ void DeveScene::Initialize(SceneData* _sceneData)
     SceneCamera_.rotate_ = objectParams["Camera"].rotation;
 
 
-    textRenderer_ = TextRenderer::GetInstance();
+    text_.Initialize(FontConfig());
 }
 
 void DeveScene::Update()
 {
-    textRenderer_->BeginFrame();
     // シーン関連更新
     static std::string str = "Hello, World!";
 #ifdef _DEBUG
@@ -222,7 +221,7 @@ void DeveScene::Update()
 
     std::wstring wstr = std::wstring(str.begin(), str.end());
     wstr += L"\nこんにちは 世界";
-    textRenderer_->DrawText(wstr, Vector2{ 100, 100 }, Vector4{ 1, 1, 1, 1 });
+    text_.Draw(wstr, Vector2{ 100, 100 }, Vector4{ 1, 1, 1, 1 });
 
     // --------------------------------
     // シーン共通更新処理
@@ -269,7 +268,6 @@ void DeveScene::Draw()
 
 
     ParticleSystem::GetInstance()->DrawParticles();
-    textRenderer_->EndFrame();
 }
 
 void DeveScene::DrawShadow()

--- a/Sample/deveScene/DeveScene.h
+++ b/Sample/deveScene/DeveScene.h
@@ -23,7 +23,7 @@
 
 #include <Features/Model/SkyBox.h>
 
-#include <Features/TextRenderer/TextRenderer.h>
+#include <Features/TextRenderer/TextGenerator.h>
 
 
 class DeveScene : public BaseScene
@@ -57,7 +57,7 @@ private:
     // ライト
     std::shared_ptr<LightGroup> lights_;
 
-    TextRenderer* textRenderer_;
+    TextGenerator text_;
 
     //------------------------------
     // シーン固有

--- a/Sample/imgui.ini
+++ b/Sample/imgui.ini
@@ -155,7 +155,7 @@ Collapsed=0
 
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=1280,701
+Size=32,32
 Collapsed=0
 
 [Window][Timeline]
@@ -291,7 +291,7 @@ Column 2  Width=56
 
 [Docking][Data]
 DockNode          ID=0x00000001 Pos=255,18 Size=325,299 Selected=0x52D7A061
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=X
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=X
   DockNode        ID=0x00000005 Parent=0x08BD597D SizeRef=983,720 Split=Y
     DockNode      ID=0x00000002 Parent=0x00000005 SizeRef=1280,463 Split=Y
       DockNode    ID=0x00000003 Parent=0x00000002 SizeRef=1042,412 Split=Y


### PR DESCRIPTION
- Object3d.PS.hlslのComputePointLightShadow関数で、テクスチャの色をマテリアルの色で乗算するように変更
- SampleFramework.cppのInitialize関数からTextRendererの初期化コードを削除し、新しいテキスト生成機能を導入
- SampleFramework.cppのDraw関数にtextRendererのEndFrame呼び出しを追加
- DeveScene.cppのInitialize関数でTextRendererのインスタンスを削除し、TextGeneratorを初期化
- DeveScene.cppのUpdate関数でテキストの描画をTextRendererからTextGeneratorに変更
- DeveScene.cppのDraw関数からtextRendererのEndFrame呼び出しを削除
- DeveScene.hでTextRendererのインクルードをTextGeneratorに変更し、クラスメンバーとしてTextGeneratorを追加
- imgui.iniのウィンドウサイズや位置に関する設定を変更し、UIのレイアウトを調整