### PR TITLE
UIクラスでtextを描画できるように

### DIFF
--- a/Engine/Features/TextRenderer/TextParam.h
+++ b/Engine/Features/TextRenderer/TextParam.h
@@ -3,6 +3,8 @@
 #include <Math/Vector/Vector2.h>
 #include <Math/Vector/Vector4.h>
 
+#include <Debug/ImGuiManager.h>
+
 struct TextParam
 {
     Vector2 scale = { 1.0f, 1.0f }; // スケール
@@ -31,5 +33,21 @@ struct TextParam
         outlineColor = _outlineColor;
         outlineScale = _outlineScale;
         return *this;
+    }
+
+    void ImGui()
+    {
+        ImGui::Checkbox("Outline", &useOutline);
+        ImGui::Checkbox("Gradient", &useGradient);
+
+        ImGui::DragFloat2("Scale", &scale.x, 0.01f);
+        ImGui::DragFloat("Rotate", &rotate, 0.01f);
+        ImGui::DragFloat2("Pivot", &pivot.x, 0.01f);
+        ImGui::Checkbox("Use Gradient", &useGradient);
+        ImGui::Checkbox("Use Outline", &useOutline);
+        ImGui::ColorEdit4("Bottom Color", &bottomColor.x);
+        ImGui::ColorEdit4("Top Color", &topColor.x);
+        ImGui::ColorEdit4("Outline Color", &outlineColor.x);
+        ImGui::DragFloat("Outline Scale", &outlineScale, 0.01f);
     }
 };

--- a/Engine/Features/UI/UIBase.cpp
+++ b/Engine/Features/UI/UIBase.cpp
@@ -16,16 +16,16 @@ void UIBase::Initialize(const std::string& _label)
 
     jsonBinder_ = std::make_unique<JsonBinder>(_label, "Resources/Data/UI/");
 
-    jsonBinder_->RegisterVariable(label_+"_pos", &position_);
-    jsonBinder_->RegisterVariable(label_+"_size", &size_);
+    jsonBinder_->RegisterVariable(label_ + "_pos", &position_);
+    jsonBinder_->RegisterVariable(label_ + "_size", &size_);
     jsonBinder_->RegisterVariable(label_ + "_rotate", &rotate_);
-    jsonBinder_->RegisterVariable(label_+"_anchor", &anchor_);
-    jsonBinder_->RegisterVariable(label_+"_isActive", reinterpret_cast<uint32_t*>(&isActive_));
-    jsonBinder_->RegisterVariable(label_+"_isVisible", reinterpret_cast<uint32_t*>(&isVisible_));
+    jsonBinder_->RegisterVariable(label_ + "_anchor", &anchor_);
+    jsonBinder_->RegisterVariable(label_ + "_isActive", reinterpret_cast<uint32_t*>(&isActive_));
+    jsonBinder_->RegisterVariable(label_ + "_isVisible", reinterpret_cast<uint32_t*>(&isVisible_));
     jsonBinder_->RegisterVariable(label_ + "_color", &color_);
-    jsonBinder_->RegisterVariable(label_+"_textureName", &textureName_);
+    jsonBinder_->RegisterVariable(label_ + "_textureName", &textureName_);
     jsonBinder_->RegisterVariable(label_ + "_directoryPath", &directoryPath_);
-    jsonBinder_->RegisterVariable(label_+"_label", &label_);
+    jsonBinder_->RegisterVariable(label_ + "_label", &label_);
 
     if (textureName_ == "")
         textureName_ = "white.png";
@@ -42,7 +42,23 @@ void UIBase::Initialize(const std::string& _label)
     sprite_->rotate_ = rotate_;
     sprite_->SetAnchor(anchor_);
 
-    //ImGuiDebugManager::GetInstance()->AddDebugWindow(_label, [&]() {ImGui(); });
+}
+
+void UIBase::Initialize(const std::string& _label, const std::wstring& _text)
+{
+    Initialize(_label, _text, FontConfig());
+}
+
+void UIBase::Initialize(const std::string& _label, const std::wstring& _text, const FontConfig& _config)
+{
+    Initialize(_label);
+
+    textGenerator_.Initialize(_config);
+
+    hasText_ = true;
+
+    text_ = _text;
+
 }
 
 void UIBase::Draw()
@@ -57,6 +73,14 @@ void UIBase::Draw()
     sprite_->SetAnchor(anchor_);
     sprite_->SetTextureHandle(textureHandle_);
     sprite_->Draw(color_);
+
+    if (hasText_)
+    {
+        textParam_.position = position_ + textOffset_;
+        textParam_.pivot = anchor_;
+
+        textGenerator_.Draw(text_, textParam_);
+    }
 }
 
 bool UIBase::IsMousePointerInside() const
@@ -145,6 +169,13 @@ void UIBase::ImGui()
         {
             jsonBinder_->Save();
         }
+
+        ImGui::SeparatorText("Text param");
+
+        ImGui::DragFloat2("offset", &textOffset_.x, 0.01f);
+        textParam_.ImGui();
+
+
     }
     ImGui::EndTabBar();
 

--- a/Engine/Features/UI/UIBase.h
+++ b/Engine/Features/UI/UIBase.h
@@ -4,6 +4,7 @@
 #include <Math/Vector/Vector4.h>
 
 #include <Features/Sprite/Sprite.h>
+#include <Features/TextRenderer/TextGenerator.h>
 
 #include <Features/Json/JsonBinder.h>
 
@@ -15,6 +16,8 @@ public:
     virtual ~UIBase();
 
     virtual void Initialize(const std::string& _label);
+    virtual void Initialize(const std::string& _label, const std::wstring& _text);
+    virtual void Initialize(const std::string& _label, const std::wstring& _text, const FontConfig& _config);
     virtual void Update() {};
     virtual void Draw();
 
@@ -26,6 +29,8 @@ public:
 
     bool IsVisible() const { return isVisible_; }
     void SetVisible(bool _isVisible) { isVisible_ = _isVisible; }
+
+    void SetTextParam(const TextParam& _textParam) { textParam_ = _textParam; }
 
     Vector4 GetColor() const { return color_; }
     virtual void SetColor(const Vector4& _color) { color_ = _color; }
@@ -74,11 +79,21 @@ protected:
 
     Vector4 color_ = { 1,1,1,1 };
 
+
     std::string label_ = "";
     std::string textureName_ = "";
     std::string directoryPath_ = "Resources/images/";
 
     std::unique_ptr<JsonBinder> jsonBinder_ = nullptr;
+
+    // text
+    TextGenerator textGenerator_ = {};
+    std::wstring text_ = L""; // テキストの内容
+    // テキストがあるかどうか
+    bool hasText_ = false;
+    TextParam textParam_ = {}; // テキストのパラメータ
+
+    Vector2 textOffset_ = { 0,0 }; // テキストのオフセット
 
 
 };

--- a/Engine/Features/UI/UIButton.cpp
+++ b/Engine/Features/UI/UIButton.cpp
@@ -26,6 +26,11 @@ void UIButton::Initialize(const std::string& _label)
     UIBase::Initialize(_label);
 }
 
+void UIButton::Initialize(const std::string& _label, const std::wstring& _text)
+{
+    UIBase::Initialize(_label, _text);
+}
+
 void UIButton::Update()
 {
 #ifdef _DEBUG

--- a/Engine/Features/UI/UIButton.h
+++ b/Engine/Features/UI/UIButton.h
@@ -24,6 +24,8 @@ public:
 
     // 初期化
     void Initialize(const std::string& _label);
+    // 初期化
+    void Initialize(const std::string& _label, const std::wstring& _text) override;
     // 更新
     void Update() override;
     // 描画

--- a/Engine/Features/UI/UIGroup.cpp
+++ b/Engine/Features/UI/UIGroup.cpp
@@ -37,11 +37,13 @@ void UIGroup::Draw()
     }
 }
 
-UIButton* UIGroup::CreateButton(const std::string& _label)
+UIButton* UIGroup::CreateButton(const std::string& _label, const std::wstring& _text)
 {
     auto button = std::make_unique<UIButton>();
-
-    button->Initialize(_label);
+    if (_text.empty())
+        button->Initialize(_label);
+    else
+        button->Initialize(_label, _text);
     buttonNavigator_.RegisterButton(button.get()); // ボタンをナビゲーターに登録
 
     uiElements_.push_back(std::move(button));
@@ -49,10 +51,13 @@ UIButton* UIGroup::CreateButton(const std::string& _label)
     return static_cast<UIButton*>(uiElements_.back().get());
 }
 
-UISprite* UIGroup::CreateSprite(const std::string& _label)
+UISprite* UIGroup::CreateSprite(const std::string& _label, const std::wstring& _text)
 {
     auto sprite = std::make_unique<UISprite>();
-    sprite->Initialize(_label);
+    if (_text.empty())
+        sprite->Initialize(_label);
+    else
+        sprite->Initialize(_label, _text);
 
     uiElements_.push_back(std::move(sprite));
 

--- a/Engine/Features/UI/UIGroup.h
+++ b/Engine/Features/UI/UIGroup.h
@@ -31,9 +31,9 @@ public:
 
 
     // ボタンの生成
-    UIButton* CreateButton(const std::string& _label);
+    UIButton* CreateButton(const std::string& _label, const std::wstring& _text = L"");
     // スプライトの生成
-    UISprite* CreateSprite(const std::string& _label);
+    UISprite* CreateSprite(const std::string& _label, const std::wstring& _text = L"");
 
 public: // 静的メンバ関数
 

--- a/Engine/Features/UI/UISprite.cpp
+++ b/Engine/Features/UI/UISprite.cpp
@@ -5,6 +5,11 @@ void UISprite::Initialize(const std::string& _label)
     UIBase::Initialize(_label);
 }
 
+void UISprite::Initialize(const std::string& _label, const std::wstring& _text)
+{
+    UIBase::Initialize(_label, _text);
+}
+
 void UISprite::Update()
 {
 #ifdef _DEBUG

--- a/Engine/Features/UI/UISprite.h
+++ b/Engine/Features/UI/UISprite.h
@@ -10,6 +10,7 @@ public:
     ~UISprite() = default;
 
     void Initialize(const std::string& _label);
+    void Initialize(const std::string& _label, const std::wstring& _text) override;
     void Update() override;
     void Draw() override;
 

--- a/Engine/GameEngine.vcxproj
+++ b/Engine/GameEngine.vcxproj
@@ -346,7 +346,7 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClInclude Include="Features\TextRenderer\AtlasData.h" />
     <ClInclude Include="Features\TextRenderer\FontCache.h" />
     <ClInclude Include="Features\TextRenderer\TextGenerator.h" />
-    <ClInclude Include="Features\TextRenderer\TextParan.h" />
+    <ClInclude Include="Features\TextRenderer\TextParam.h" />
     <ClInclude Include="Features\TextRenderer\TextRenderer.h" />
     <ClInclude Include="Features\UI\ButtonNavigator.h" />
     <ClInclude Include="Features\UI\UIBase.h" />

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -993,7 +993,7 @@
     <ClInclude Include="Features\TextRenderer\TextGenerator.h">
       <Filter>Features\Text</Filter>
     </ClInclude>
-    <ClInclude Include="Features\TextRenderer\TextParan.h">
+    <ClInclude Include="Features\TextRenderer\TextParam.h">
       <Filter>Features\Text</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
- `TextParam`構造体に`ImGui`メソッドを追加し、テキストパラメータの設定UIを実装
- `UIBase`クラスの`Initialize`メソッドをオーバーロードし、テキストを受け取る機能を追加
- `UIBase`クラスの`Draw`メソッドにテキスト描画処理を追加
- `UIButton`と`UISprite`クラスにテキストを受け取る`Initialize`メソッドを追加
- `UIGroup`クラスの`CreateButton`および`CreateSprite`メソッドを変更し、テキストオプションを追加
- 新しい`GameUI`クラスを追加し、初期化、更新、描画処理のメソッドを定義