### PR TITLE
日本語文字のプリロードとシェーダーの追加

### DIFF
--- a/Engine/Features/TextRenderer/AtlasData.cpp
+++ b/Engine/Features/TextRenderer/AtlasData.cpp
@@ -167,6 +167,15 @@ void AtlasData::PreloadCommonCharacters()
     {
         GetGlyph(static_cast<wchar_t>(c));
     }
+    for (wchar_t c = L'あ'; c < L'ん'; c++)
+    {
+        GetGlyph(c);
+    }
+    for (wchar_t c = L'ア'; c < L'ン'; c++)
+    {
+        GetGlyph(c);
+    }
+
 }
 
 Vector2 AtlasData::GetStringAreaSize(const std::wstring& _text, const Vector2& _scale)

--- a/Engine/Features/TextRenderer/AtlasData.h
+++ b/Engine/Features/TextRenderer/AtlasData.h
@@ -23,7 +23,7 @@ struct GlyphInfo
 
 struct FontConfig
 {
-    Vector2 atlasSize = { 4096,4096 }; // アトラスの幅
+    Vector2 atlasSize = { 1024,1024 }; // アトラスの幅
     float fontSize = 32.0f; // フォントサイズ
     std::string fontFilePath = "Resources/Fonts/NotoSansJP-Regular.ttf"; // フォントファイルのパス
 };

--- a/Engine/Features/TextRenderer/TextRenderer.h
+++ b/Engine/Features/TextRenderer/TextRenderer.h
@@ -35,6 +35,7 @@ public:
     void Finalize();
 
     void BeginFrame();
+
     void EndFrame();
 
     void DrawText(const std::wstring& _text, AtlasData* _atlas, const Vector2& _pos, const Vector4& _color = { 1,1,1,1 });


### PR DESCRIPTION
- `AtlasData.cpp` に日本語のひらがな（あ〜ん）とカタカナ（ア〜ン）を取得するループを追加
- `AtlasData.h` の `GlyphInfo` 構造体で `atlasSize` を 4096x4096 から 1024x1024 に変更