### PR TITLE
DepthBasedOutlineをCSで実装

### DIFF
--- a/Engine/Features/PostEffects/DepthBasedOutLine.cpp
+++ b/Engine/Features/PostEffects/DepthBasedOutLine.cpp
@@ -1,124 +1,169 @@
-#include "DepthBasedOutLine.h"
+#include "DepthBasedOutline.h"
 
+#include <Core/WinApp/WinApp.h>
 #include <Core/DXCommon/DXCommon.h>
 #include <Core/DXCommon/PSOManager/PSOManager.h>
+#include <Core/DXCommon/SRVManager/SRVManager.h>
 #include <Core/DXCommon/RTV/RTVManager.h>
+#include <Framework/LayerSystem/LayerSystem.h>
 #include <Debug/Debug.h>
+#include <Features/Camera/Camera/Camera.h>
 
 #include <Math/Matrix/MatrixFunction.h>
 
+#include <Debug/ImGuiDebugManager.h>
 
 void DepthBasedOutLine::Initialize()
 {
-    CreatePSOForDepthBasedOutLine();
+    CreateConstantBuffer(sizeof(DepthBasedOutLineData));
 
-    // カメラの逆行列を格納するバッファを作成
-
-    inverseMatrixBuffer_ = DXCommon::GetInstance()->CreateBufferResource(sizeof(Matrix4x4));
-    inverseMatrixBuffer_->Map(0, nullptr, reinterpret_cast<void**>(&inverseMatrixData_));
-
-    *inverseMatrixData_ = Matrix4x4::Identity();
-
-
+    // PSOとルートシグネチャを生成
+    CreateRootSignature();
+    CreatePipelineState();
 }
 
-void DepthBasedOutLine::Set(const std::string& _depthTextureName)
+void DepthBasedOutLine::Apply(const std::string& _input, const std::string& _output)
 {
-    SetPSO();
-    SetRootSignature();
+    auto cmdList = DXCommon::GetInstance()->GetCommandList();
 
-    // カメラの逆射影行列をセット
+    UpdateData();
 
-    Matrix4x4 vpmat = camera_->GetViewProjection();
+    // パイプラインステート設定
+    cmdList->SetPipelineState(pipelineState_.Get());
+    cmdList->SetComputeRootSignature(rootSignature_.Get());
 
-    *inverseMatrixData_ = Inverse(vpmat);
+    // ルートパラメータ設定
+    // CBV (b0) - 定数バッファ
+    cmdList->SetComputeRootConstantBufferView(0, constantBuffer_->GetGPUVirtualAddress());
 
-    DXCommon::GetInstance()->GetCommandList()->SetGraphicsRootConstantBufferView(1, inverseMatrixBuffer_->GetGPUVirtualAddress());
-    RTVManager::GetInstance()->GetRenderTexture(_depthTextureName)->QueueCommandDSVtoSRV(2);
+    auto rtvManager = RTVManager::GetInstance();
+    UINT inputSRVIndex = rtvManager->GetRenderTexture(_input)->GetSRVindexofRTV();
+    uint32_t outputUAVIndex = LayerSystem::GetUAVIndex(_output);
+    uint32_t depthSRVIndex = rtvManager->GetRenderTexture(_input)->GetSRVindexofDSV();
+
+    rtvManager->GetRenderTexture(_input)->ChangeRTVState(cmdList, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    rtvManager->GetRenderTexture(_input)->ChangeDSVState(cmdList, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    rtvManager->GetRenderTexture(_output)->ChangeRTVState(cmdList, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    // SRV (t0) - 入力テクスチャ
+    cmdList->SetComputeRootDescriptorTable(1, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(inputSRVIndex));
+    // SRV (t1) 深度テクスチャ
+    cmdList->SetComputeRootDescriptorTable(2, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(depthSRVIndex));
+    // UAV (u0) - 出力テクスチャ
+    cmdList->SetComputeRootDescriptorTable(3, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(outputUAVIndex));
+
+    // スレッドグループ数計算 (8x8のスレッドグループ)
+    uint32_t dispatchX = (WinApp::kWindowWidth_ + 7) / 8;
+    uint32_t dispatchY = (WinApp::kWindowHeight_ + 7) / 8;
+
+    // Dispatch実行
+    cmdList->Dispatch(dispatchX, dispatchY, 1);
+
+
+    rtvManager->GetRenderTexture(_input)->ChangeDSVState(cmdList, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+    rtvManager->GetRenderTexture(_output)->ChangeRTVState(cmdList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 }
 
-
-void DepthBasedOutLine::SetPSO()
+void DepthBasedOutLine::SetData(DepthBasedOutLineData* _data)
 {
-    PSOManager::GetInstance()->SetRegisterPSO(name_);
+    if (_data)
+    {
+        data_ = _data;
+    }
 }
 
-void DepthBasedOutLine::SetRootSignature()
+void DepthBasedOutLine::SetCamera(Camera* camera)
 {
-    PSOManager::GetInstance()->SetRegisterRootSignature(name_);
+    if (camera)
+    {
+        camera_ = camera;
+    }
 }
 
-void DepthBasedOutLine::CreatePSOForDepthBasedOutLine()
+void DepthBasedOutLine::CreatePipelineState()
 {
+
     HRESULT hr = S_FALSE;
 
+#pragma region Shader
+    // Compute Shaderをコンパイルする
+    Microsoft::WRL::ComPtr<IDxcBlob> computeShaderBlob =
+        PSOManager::GetInstance()->ComplieShader(L"DepthBasedOutline.CS.hlsl", L"cs_6_0");
+    assert(computeShaderBlob != nullptr);
+#pragma endregion
 
-    // ルートシグネチャのためのサンプラー設定
-    D3D12_STATIC_SAMPLER_DESC samplers[2] = {};
+    // Compute PSOを生成する
+    D3D12_COMPUTE_PIPELINE_STATE_DESC computePipelineStateDesc{};
+    computePipelineStateDesc.pRootSignature = rootSignature_.Get();
+    computePipelineStateDesc.CS = { computeShaderBlob->GetBufferPointer(), computeShaderBlob->GetBufferSize() };
+    computePipelineStateDesc.NodeMask = 0;
+    computePipelineStateDesc.CachedPSO.pCachedBlob = nullptr;
+    computePipelineStateDesc.CachedPSO.CachedBlobSizeInBytes = 0;
+    computePipelineStateDesc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
 
-    // 通常テクスチャ用サンプラー
-    samplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-    samplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-    samplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-    samplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-    samplers[0].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-    samplers[0].MaxLOD = D3D12_FLOAT32_MAX;
-    samplers[0].ShaderRegister = 0; // s0
-    samplers[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+    // PSOを生成
+    hr = DXCommon::GetInstance()->GetDevice()->CreateComputePipelineState(&computePipelineStateDesc, IID_PPV_ARGS(&pipelineState_));
+    assert(SUCCEEDED(hr));
+}
 
-    // 深度テクスチャ用サンプラー
-    samplers[1].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-    samplers[1].AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    samplers[1].AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    samplers[1].AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-    samplers[1].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
-    samplers[1].MaxLOD = D3D12_FLOAT32_MAX;
-    samplers[1].ShaderRegister = 1; // s1
-    samplers[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+void DepthBasedOutLine::CreateRootSignature()
+{
+    HRESULT hr = S_OK;
 
-    // テクスチャSRVのためのディスクリプタレンジ
-    D3D12_DESCRIPTOR_RANGE descriptorRanges[1] = {};
 
-    // 通常テクスチャ用レンジ
-    descriptorRanges[0].BaseShaderRegister = 0; // t0
-    descriptorRanges[0].NumDescriptors = 1;
-    descriptorRanges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-    descriptorRanges[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+    // descriptorRange
+    D3D12_DESCRIPTOR_RANGE descriptorRange[3] = {};
 
-    D3D12_DESCRIPTOR_RANGE descriptorRangesforDepth[1] = {};
-    // 深度テクスチャ用レンジ
-    descriptorRangesforDepth[0].BaseShaderRegister = 1; // t1
-    descriptorRangesforDepth[0].NumDescriptors = 1;
-    descriptorRangesforDepth[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-    descriptorRangesforDepth[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+    // SRV (t0) - 入力テクスチャ
+    descriptorRange[0].BaseShaderRegister = 0;
+    descriptorRange[0].NumDescriptors = 1;
+    descriptorRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    descriptorRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    // SRV (t1) - depthテクスチャ
+    descriptorRange[1].BaseShaderRegister = 1;
+    descriptorRange[1].NumDescriptors = 1;
+    descriptorRange[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+    descriptorRange[1].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    // UAV (u0) - 出力テクスチャ
+    descriptorRange[2].BaseShaderRegister = 0;
+    descriptorRange[2].NumDescriptors = 1;
+    descriptorRange[2].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
+    descriptorRange[2].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
     // ディスクリプタテーブルの作成
-    D3D12_ROOT_PARAMETER rootParameters[3] = {};
+    D3D12_ROOT_PARAMETER rootParameters[4] = {};
+
+    // コンスタントバッファ (b0) DepthBasedOutlineData
+    rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+    rootParameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[0].Descriptor.ShaderRegister = 0;
 
     // テクスチャ用ディスクリプタテーブル
-    rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
-    rootParameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-    rootParameters[0].DescriptorTable.NumDescriptorRanges = 1;
-    rootParameters[0].DescriptorTable.pDescriptorRanges = descriptorRanges;
+    rootParameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[1].DescriptorTable.NumDescriptorRanges = 1;
+    rootParameters[1].DescriptorTable.pDescriptorRanges = &descriptorRange[0];
 
-    // カメラの逆射影行列
-    rootParameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
-    rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-    rootParameters[1].Descriptor.ShaderRegister = 0;
-
-
+    // 深度テクスチャ用ディスクリプタテーブル
     rootParameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
-    rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+    rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
     rootParameters[2].DescriptorTable.NumDescriptorRanges = 1;
-    rootParameters[2].DescriptorTable.pDescriptorRanges = descriptorRangesforDepth;
+    rootParameters[2].DescriptorTable.pDescriptorRanges = &descriptorRange[1];
+
+    // 出力テクスチャ用ディスクリプタテーブル
+    rootParameters[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+    rootParameters[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+    rootParameters[3].DescriptorTable.NumDescriptorRanges = 1;
+    rootParameters[3].DescriptorTable.pDescriptorRanges = &descriptorRange[2];
+
 
     // ルートシグネチャ記述の設定
     D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc = {};
     rootSignatureDesc.NumParameters = _countof(rootParameters);
     rootSignatureDesc.pParameters = rootParameters;
-    rootSignatureDesc.NumStaticSamplers = _countof(samplers);
-    rootSignatureDesc.pStaticSamplers = samplers;
-    rootSignatureDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+    rootSignatureDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE; // Compute用
 
     // ルートシグネチャのシリアライズと作成
     Microsoft::WRL::ComPtr<ID3DBlob> signatureBlob = nullptr;
@@ -135,63 +180,40 @@ void DepthBasedOutLine::CreatePSOForDepthBasedOutLine()
         return;
     }
 
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> rootSignature;
     hr = DXCommon::GetInstance()->GetDevice()->CreateRootSignature(
         0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize(),
-        IID_PPV_ARGS(&rootSignature));
+        IID_PPV_ARGS(&rootSignature_));
 
     if (FAILED(hr)) {
         assert(false && "Failed to create root signature");
         return;
     }
+}
 
-    // シェーダーのコンパイル
-    Microsoft::WRL::ComPtr<IDxcBlob> vsBlob =
-        PSOManager::GetInstance()->ComplieShader(L"FullScreen.VS.hlsl", L"vs_6_0");
-    Microsoft::WRL::ComPtr<IDxcBlob> psBlob =
-        PSOManager::GetInstance()->ComplieShader(L"DepthBasedOutline.hlsl", L"ps_6_0");
-
-    // PSO記述子の設定
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
-    psoDesc.pRootSignature = rootSignature.Get();
-
-    // シェーダー設定
-    psoDesc.VS = { vsBlob->GetBufferPointer(), vsBlob->GetBufferSize() };
-    psoDesc.PS = { psBlob->GetBufferPointer(), psBlob->GetBufferSize() };
-
-    // ブレンド設定
-    psoDesc.BlendState.RenderTarget[0].BlendEnable = FALSE;
-    psoDesc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
-
-    // ラスタライザー設定
-    psoDesc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
-    psoDesc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
-
-    // 深度設定 - フルスクリーンパスでは無効化
-    psoDesc.DepthStencilState.DepthEnable = FALSE;
-
-    // レンダーターゲット設定
-    psoDesc.NumRenderTargets = 1;
-    psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
-    psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
-
-    // その他の設定
-    psoDesc.SampleMask = D3D12_DEFAULT_SAMPLE_MASK;
-    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-    psoDesc.SampleDesc.Count = 1;
-
-    // PSO作成
-    Microsoft::WRL::ComPtr<ID3D12PipelineState> pipelineState;
-    hr = DXCommon::GetInstance()->GetDevice()->CreateGraphicsPipelineState(
-        &psoDesc, IID_PPV_ARGS(&pipelineState));
-
-    if (FAILED(hr)) {
-        assert(false && "Failed to create pipeline state");
+void DepthBasedOutLine::UpdateData()
+{
+    if (!data_ || !camera_)
         return;
-    }
 
-    // PSOManagerに登録
-    PSOManager::GetInstance()->RegisterPSO("DepthBasedOutline", pipelineState.Get());
-    PSOManager::GetInstance()->RegisterRootSignature("DepthBasedOutline", rootSignature.Get());
+    // カメラの逆射影行列を設定
+    data_->inverseViewProjectionMatrix = Inverse(camera_->GetViewProjection());
+    // 定数バッファを更新
+    UpdateConstantBuffer(data_, sizeof(DepthBasedOutLineData));
+}
+
+void DepthBasedOutLineData::ImGui()
+{
+#ifdef _DEBUG
+    ImGui::PushID(this);
+
+    ImGui::SliderFloat("Edge Threshold", &edgeThreshold, 0.0f, 10.0f);
+    ImGui::SliderFloat("Edge Intensity", &edgeIntensity, 0.0f, 1.0f);
+    ImGui::SliderFloat("Edge Width", &edgeWidth, 1.0f, 3.0f);
+    ImGui::ColorEdit3("Edge Color", &edgeColor.x);
+    ImGui::SliderFloat("Edge Color Intensity", &edgeColorIntensity, 0.0f, 1.0f);
+    ImGui::Checkbox("Enable Color Blending", reinterpret_cast<bool*>(&enableColorBlending));
+
+    ImGui::PopID();
+#endif // _DEBUG
 
 }

--- a/Engine/Features/PostEffects/DepthBasedOutLine.h
+++ b/Engine/Features/PostEffects/DepthBasedOutLine.h
@@ -1,43 +1,46 @@
 #pragma once
 
-#include <Features/Camera/Camera/Camera.h>
+#include <Features/PostEffects/PostEffectBase.h>
 
-class DepthBasedOutLine
+#include <Math/Vector/Vector3.h>
+#include <Math/Matrix/Matrix4x4.h>
+
+struct DepthBasedOutLineData
+{
+    Matrix4x4 inverseViewProjectionMatrix; // カメラの逆射影行列
+
+    float edgeThreshold = 0.5f; // エッジの閾値 (0.0~10.0くらい)
+    float edgeIntensity = 0.5f; // エッジの強度 (0.0~1.0)
+    float edgeWidth = 1.0f; // エッジの幅 (1.0~3.0くらい)
+    int enableColorBlending = 1; // カラーブレンディング有効（0:無効, 1:有効）
+
+    Vector3 edgeColor = { 1.0f, 1.0f, 1.0f }; // エッジの色（RGB）
+    float edgeColorIntensity = 1.0f; // エッジ色の強度（0.0~1.0）
+
+    void ImGui();
+};
+
+class Camera;
+class DepthBasedOutLine : public PostEffectBase
 {
 public:
-    static DepthBasedOutLine* GetInstance()
-    {
-        static DepthBasedOutLine instance;
-        return &instance;
-    }
+    void Initialize() override;
 
+    void Apply(const std::string& _input, const std::string& _output) override;
 
-    void Initialize();
+    void SetData(DepthBasedOutLineData* _data);
 
-    void Set(const std::string& _depthTextureName);
-
-    void SetCamera(Camera* _camera) { camera_ = _camera; }
-    void SetDepthTexture(ID3D12Resource* _depthTexture) { depthTexture_ = _depthTexture; }
+    void SetCamera(Camera* camera);
 
 private:
-    void SetPSO();
-    void SetRootSignature();
+    void CreatePipelineState();
 
+    void CreateRootSignature();
 
-    void CreatePSOForDepthBasedOutLine();
-
-
-    Camera* camera_ = nullptr;
-    ID3D12Resource* depthTexture_ = nullptr;
-
-    std::string name_ = "DepthBasedOutline";
-
-    Microsoft::WRL::ComPtr<ID3D12Resource> inverseMatrixBuffer_ = nullptr;
-    Matrix4x4* inverseMatrixData_ = nullptr;
-
+    void UpdateData();
 private:
-    DepthBasedOutLine() = default;
-    ~DepthBasedOutLine() = default;
-    DepthBasedOutLine(const DepthBasedOutLine&) = delete;
-    DepthBasedOutLine& operator=(const DepthBasedOutLine&) = delete;
+
+    Camera* camera_ = nullptr; // カメラへのポインタ
+
+    DepthBasedOutLineData* data_ = nullptr; // データへのポインタ
 };

--- a/Engine/Framework/LayerSystem/LayerSystem.cpp
+++ b/Engine/Framework/LayerSystem/LayerSystem.cpp
@@ -34,7 +34,7 @@ LayerID LayerSystem::CreateLayer(const std::string& layerName, int32_t _priority
         // レイヤーのRenderTargetを作成
     LayerID layerID = RTVManager::GetInstance()->
         CreateRenderTarget(layerName, WinApp::kWindowWidth_, WinApp::kWindowHeight_,
-            DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Vector4(0.0f, 0.0f, 0.0f, 0.0f), false);
+            DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Vector4(0.0f, 0.0f, 0.0f, 0.0f), true);
 
     instance_->layerInfos_.emplace(layerID, LayerInfo{ layerName, _priority, true, nullptr,false,"",0,false });
     instance_->layerInfos_[layerID].renderTarget = RTVManager::GetInstance()->GetRenderTexture(layerName);

--- a/Engine/GameEngine.vcxproj
+++ b/Engine/GameEngine.vcxproj
@@ -209,7 +209,7 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClCompile Include="Features\Model\SkyBox.cpp" />
     <ClCompile Include="Features\Model\Transform\WorldTransform.cpp" />
     <ClCompile Include="Features\PostEffects\BoxFilter.cpp" />
-    <ClCompile Include="Features\PostEffects\DepthBasedOutLine.cpp" />
+    <ClCompile Include="Features\PostEffects\DepthBasedOutline.cpp" />
     <ClCompile Include="Features\PostEffects\Dissolve.cpp" />
     <ClCompile Include="Features\PostEffects\PostEffectBase.cpp" />
     <ClCompile Include="Features\Scene\Manager\SceneManager.cpp" />
@@ -336,7 +336,7 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClInclude Include="Features\Model\SkyBox.h" />
     <ClInclude Include="Features\Model\Transform\WorldTransform.h" />
     <ClInclude Include="Features\PostEffects\BoxFilter.h" />
-    <ClInclude Include="Features\PostEffects\DepthBasedOutLine.h" />
+    <ClInclude Include="Features\PostEffects\DepthBasedOutline.h" />
     <ClInclude Include="Features\PostEffects\Dissolve.h" />
     <ClInclude Include="Features\PostEffects\PostEffectBase.h" />
     <ClInclude Include="Features\Scene\Interface\BaseScene.h" />
@@ -433,6 +433,10 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </FxCompile>
     <FxCompile Include="Resources\Shader\Composite.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="Resources\Shader\DepthBasedOutline.CS.hlsl">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </FxCompile>

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -513,9 +513,6 @@
     <ClCompile Include="Features\Effect\Modifier\Preset\AlphaOverLifetime.cpp">
       <Filter>Features\Effect\Modifier\Preset</Filter>
     </ClCompile>
-    <ClCompile Include="Features\PostEffects\DepthBasedOutLine.cpp">
-      <Filter>Features\PosttEffects</Filter>
-    </ClCompile>
     <ClCompile Include="Features\Model\Primitive\Triangle.cpp">
       <Filter>Features\Model\Primitive</Filter>
     </ClCompile>
@@ -596,6 +593,9 @@
       <Filter>Features\PosttEffects</Filter>
     </ClCompile>
     <ClCompile Include="Features\PostEffects\PostEffectBase.cpp">
+      <Filter>Features\PosttEffects</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\PostEffects\DepthBasedOutline.cpp">
       <Filter>Features\PosttEffects</Filter>
     </ClCompile>
   </ItemGroup>
@@ -924,9 +924,6 @@
     <ClInclude Include="Features\Effect\Modifier\Preset\AlphaOverLifetime.h">
       <Filter>Features\Effect\Modifier\Preset</Filter>
     </ClInclude>
-    <ClInclude Include="Features\PostEffects\DepthBasedOutLine.h">
-      <Filter>Features\PosttEffects</Filter>
-    </ClInclude>
     <ClInclude Include="Features\Model\Primitive\Triangle.h">
       <Filter>Features\Model\Primitive</Filter>
     </ClInclude>
@@ -1017,6 +1014,9 @@
     <ClInclude Include="Features\PostEffects\BoxFilter.h">
       <Filter>Features\PosttEffects</Filter>
     </ClInclude>
+    <ClInclude Include="Features\PostEffects\DepthBasedOutline.h">
+      <Filter>Features\PosttEffects</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Resources\Shader\FullScreen.PS.hlsl">
@@ -1096,6 +1096,9 @@
     </FxCompile>
     <FxCompile Include="Resources\Shader\Composite.hlsl">
       <Filter>Shaders</Filter>
+    </FxCompile>
+    <FxCompile Include="Resources\Shader\DepthBasedOutline.CS.hlsl">
+      <Filter>Shaders\PostEffects</Filter>
     </FxCompile>
   </ItemGroup>
 </Project>

--- a/Engine/Resources/Shader/DepthBasedOutline.CS.hlsl
+++ b/Engine/Resources/Shader/DepthBasedOutline.CS.hlsl
@@ -1,0 +1,98 @@
+#include  "Resources/Shader/FullScreen.hlsli"
+
+
+cbuffer ConstantBuffer : register(b0)
+{
+    float4x4 gInverseProjectionMatrix;
+
+    float gEdgeThreshold; // エッジの閾値 (0.0~10.0くらい)
+    float gEdgeIntensity; // エッジの強度 (0.0~1.0)
+    float gEdgeWidth; // エッジの幅 (1.0~3.0くらい)
+    int gEnableColorBlending; // カラーブレンディング有効（0:無効, 1:有効）
+
+    float3 gEdgeColor; // エッジの色（RGB）
+    float gEdgeColorIntensity; // エッジ色の強度（0.0~1.0）
+
+}
+
+Texture2D<float4> gTexture : register(t0);
+
+Texture2D<float> gDepthTexture : register(t1);
+
+RWTexture2D<float4> gOutputTexture : register(u0);
+
+
+static const float2 kIndex3x3[3][3] =
+{
+    { { -1.0f, -1.0f }, { 0.0f, -1.0f }, { 1.0f, -1.0f } },
+    { { -1.0f, 0.0f }, { 0.0f, 0.0f }, { 1.0f, 0.0f } },
+    { { -1.0f, 1.0f }, { 0.0f, 1.0f }, { 1.0f, 1.0f } },
+
+};
+
+static const float kSobelHorizontal[3][3] =
+{
+    { -1.0f / 8.0f, 0.0f, 1.0f / 8.0f },
+    { -2.0f / 8.0f, 0.0f, 2.0f / 8.0f },
+    { -1.0f / 8.0f, 0.0f, 1.0f / 8.0f }
+};
+
+static const float kSobelVertical[3][3] =
+{
+    { -1.0f /8.0f, -2.0f / 8.0f, -1.0f / 8.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 1.0f / 8.0f, 2.0f / 8.0f, 1.0f / 8.0f }
+};
+
+[numthreads(8, 8, 1)]
+void main(uint3 id : SV_DispatchThreadID)
+{
+
+    uint width, height;
+    gTexture.GetDimensions(width, height);
+
+    if (id.x >= width || id.y >= height)
+        return;
+
+    float2 difference = float2(0.0f, 0.0f); // 縦横それぞれの結果を格納する変数
+
+    for (int x = 0; x < 3; ++x)
+    {
+        for (int y = 0; y < 3; ++y)
+        {
+            int2 texcoord = int2(id.xy) + int2(kIndex3x3[x][y] * gEdgeWidth);
+            texcoord = clamp(texcoord, int2(0, 0), int2(width - 1, height - 1));
+
+            float ndcDepth = gDepthTexture[texcoord];
+            float4 viewSpace = mul(float4(0.0f, 0.0f, ndcDepth, 1.0f), gInverseProjectionMatrix); // TODO
+            float viewZ = viewSpace.z * rcp(viewSpace.w);
+
+            difference.x += viewZ * kSobelHorizontal[x][y];
+            difference.y += viewZ * kSobelVertical[x][y];
+        }
+    }
+
+    float weight = length(difference) * gEdgeIntensity;
+    weight = saturate(weight * gEdgeThreshold);
+
+    float4 originalColor = gTexture[id.xy];
+
+    float4 output;
+
+    if (gEnableColorBlending)
+    {
+        // エッジ色とのブレンディング
+        float3 edgeColor = lerp(originalColor.rgb, gEdgeColor, weight * gEdgeColorIntensity);
+        output.rgb = (1.0f - weight) * originalColor.rgb + weight * edgeColor;
+    }
+    else
+    {
+        // 従来の暗化処理
+        output.rgb = (1.0f - weight) * originalColor.rgb;
+    }
+
+    output.a = 1.0f;
+
+
+    gOutputTexture[id.xy] = output;
+}

--- a/Engine/Resources/Shader/DepthBasedOutline.hlsl
+++ b/Engine/Resources/Shader/DepthBasedOutline.hlsl
@@ -39,12 +39,6 @@ static const float kPrewittVertical[3][3] =
     { 1.0f / 6.0f, 1.0f / 6.0f, 1.0f / 6.0f }
 };
 
-
-float Luminance(float3 _v)
-{
-    return dot(_v, float3(0.2125f, 0.7154f, 0.0721f));
-}
-
 PixelShaderOutput main(VertexOutput _input)
 {
     PixelShaderOutput output;
@@ -63,7 +57,7 @@ PixelShaderOutput main(VertexOutput _input)
 
             float ndcDepth = gDepthTexture.Sample(gDepthSampler, texcoord);
             float4 viewSpace = mul(float4(0.0f, 0.0f, ndcDepth, 1.0f), gInverseProjectionMatrix);// TODO
-            float viewZ = viewSpace.z * rcp(viewSpace.w); 
+            float viewZ = viewSpace.z * rcp(viewSpace.w);
 
             difference.x += viewZ * kPrewittHorizontal[x][y];
             difference.y += viewZ * kPrewittVertical[x][y];


### PR DESCRIPTION
- `DepthBasedOutLine` クラスが `PostEffectBase` を継承し、`Initialize` メソッドをオーバーライド
- 新しい `Apply` メソッドを追加し、テクスチャ処理ロジックを実装
- `DepthBasedOutLineData` 構造体を追加し、エッジ処理に関連する新パラメータを定義
- `UpdateData` メソッドを追加し、カメラの逆行列を更新
- HLSL シェーダーコードを更新し、エッジ検出ロジックを追加
- `LayerSystem.cpp` でのレンダーターゲット設定を変更