### PR TITLE
グレースケールエフェクトの実装

### DIFF
--- a/Engine/Features/PostEffects/GrayScale.cpp
+++ b/Engine/Features/PostEffects/GrayScale.cpp
@@ -1,0 +1,174 @@
+#include "GrayScale.h"
+
+#include <Core/WinApp/WinApp.h>
+#include <Core/DXCommon/DXCommon.h>
+#include <Core/DXCommon/RTV/RTVManager.h>
+#include <Core/DXCommon/PSOManager/PSOManager.h>
+#include <Core/DXCommon/TextureManager/TextureManager.h>
+
+#include <Framework/LayerSystem/LayerSystem.h>
+#include <Debug/Debug.h>
+
+void GrayScale::Initialize()
+{
+    CreateConstantBuffer(sizeof(GrayScaleData));
+
+    CreateRootSignature();
+    CreatePipelineState();
+
+}
+
+void GrayScale::Apply(const std::string& _input, const std::string& _output)
+{
+    auto cmdList = DXCommon::GetInstance()->GetCommandList();
+
+    UpdateData();
+
+    auto rtvManager = RTVManager::GetInstance();
+    // パイプラインステート設定
+    cmdList->SetPipelineState(pipelineState_.Get());
+    cmdList->SetGraphicsRootSignature(rootSignature_.Get());
+
+    rtvManager->GetRenderTexture(_output)->SetRenderTexture();
+    rtvManager->GetRenderTexture(_input)->ChangeRTVState(cmdList, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    uint32_t srvIndex = rtvManager->GetRenderTexture(_input)->GetSRVindexofRTV();
+    // ルートパラメータ設定
+    // CBV (b0) - 定数バッファ
+    cmdList->SetGraphicsRootConstantBufferView(0, constantBuffer_->GetGPUVirtualAddress());
+
+    cmdList->SetGraphicsRootDescriptorTable(1, SRVManager::GetInstance()->GetGPUSRVDescriptorHandle(srvIndex));
+    // Dispatch実行
+    cmdList->DrawInstanced(3, 1, 0, 0);
+}
+
+void GrayScale::SetData(GrayScaleData* _data)
+{
+    if (_data)
+    {
+        data_ = _data;
+        UpdateData();
+    }
+}
+
+void GrayScale::CreatePipelineState()
+{
+    HRESULT hr = S_FALSE;
+
+#pragma region Shader
+
+    Microsoft::WRL::ComPtr<IDxcBlob> vertexShaderBlob = PSOManager::GetInstance()->ComplieShader(L"FullScreen.VS.hlsl", L"vs_6_0");
+    assert(vertexShaderBlob != nullptr);
+    Microsoft::WRL::ComPtr<IDxcBlob> pixelShaderBlob = PSOManager::GetInstance()->ComplieShader(L"GrayScale.hlsl", L"ps_6_0");
+    assert(pixelShaderBlob != nullptr);
+#pragma endregion
+    D3D12_DEPTH_STENCIL_DESC depthStencilDesc{};
+    depthStencilDesc.DepthEnable = false;
+
+    D3D12_INPUT_LAYOUT_DESC inputLayoutDesc{};
+    inputLayoutDesc.pInputElementDescs = nullptr;
+    inputLayoutDesc.NumElements = 0;
+
+    D3D12_BLEND_DESC blendDesc{};
+    blendDesc = PSOManager::GetInstance()->GetBlendDesc(PSOFlags::BlendMode::Normal);
+
+    D3D12_RASTERIZER_DESC rasterizerDesc{};
+    rasterizerDesc.CullMode = D3D12_CULL_MODE_NONE;
+    rasterizerDesc.FillMode = D3D12_FILL_MODE_SOLID;
+
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineStateDesc{};
+    graphicsPipelineStateDesc.pRootSignature = rootSignature_.Get();                                                // RootSignature
+    graphicsPipelineStateDesc.BlendState = blendDesc;                                                               // BlendState
+    graphicsPipelineStateDesc.InputLayout = inputLayoutDesc;                                                        // InputLayout
+    graphicsPipelineStateDesc.VS = { vertexShaderBlob->GetBufferPointer(), vertexShaderBlob->GetBufferSize() };	    // VertexShader
+    graphicsPipelineStateDesc.PS = { pixelShaderBlob->GetBufferPointer(), pixelShaderBlob->GetBufferSize() };       // PixelShader
+    graphicsPipelineStateDesc.RasterizerState = rasterizerDesc;                                                     // RasterizerState
+    // 追加の DRTV の情報
+    graphicsPipelineStateDesc.NumRenderTargets = 1;
+    graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+    graphicsPipelineStateDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+
+    graphicsPipelineStateDesc.DepthStencilState = depthStencilDesc;
+    graphicsPipelineStateDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+    // どのように画面に色を打ち込むかの設定 (気にしなくて良い)
+    graphicsPipelineStateDesc.SampleDesc.Count = 1;
+    graphicsPipelineStateDesc.SampleMask = D3D12_DEFAULT_SAMPLE_MASK;
+
+    graphicsPipelineStateDesc.BlendState = blendDesc;
+
+    // PSOを生成
+    hr = DXCommon::GetInstance()->GetDevice()->CreateGraphicsPipelineState(&graphicsPipelineStateDesc, IID_PPV_ARGS(&pipelineState_));
+}
+
+void GrayScale::CreateRootSignature()
+{
+    HRESULT hr = S_FALSE;
+
+    //Samplerの設定
+    D3D12_STATIC_SAMPLER_DESC staticSamplers[1] = {};
+    staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR; // バイリニアフィルタ
+    staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP; // 0-1の範囲外をリピート
+    staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    staticSamplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    staticSamplers[0].ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL; // 比較しない
+    staticSamplers[0].BorderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE;
+    staticSamplers[0].MaxLOD = D3D12_FLOAT32_MAX; // あらかじめのMipmapを使う
+    staticSamplers[0].ShaderRegister = 0;
+    staticSamplers[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL; // PixelShaderで使う
+
+#pragma region RootSignature
+    // RootSignatureを生成する
+    D3D12_ROOT_SIGNATURE_DESC descriptionRootSignature{};
+    descriptionRootSignature.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE; // Compute用
+
+
+    //descriptorRange
+    D3D12_DESCRIPTOR_RANGE descriptorRange[1] = {};
+    descriptorRange[0].BaseShaderRegister = 0;//０から始まる
+    descriptorRange[0].NumDescriptors = 1;//数は１つ
+    descriptorRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;//SRVを使う
+    descriptorRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+    // RootParameter作成
+    D3D12_ROOT_PARAMETER rootParameters[2] = {};
+
+    // CBV (b0) - 定数バッファ
+    rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+    rootParameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+    rootParameters[0].Descriptor.ShaderRegister = 0;
+
+    // テクスチャ
+    rootParameters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;//DescriptorTableで使う
+    rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;			//pixelShaderで使う
+    rootParameters[1].DescriptorTable.pDescriptorRanges = descriptorRange;		//tableの中身の配列を指定
+    rootParameters[1].DescriptorTable.NumDescriptorRanges = _countof(descriptorRange);//tableで利用する数
+
+    descriptionRootSignature.pParameters = rootParameters;
+    descriptionRootSignature.NumParameters = _countof(rootParameters);
+
+    descriptionRootSignature.pStaticSamplers = staticSamplers;
+    descriptionRootSignature.NumStaticSamplers = _countof(staticSamplers);
+
+    // シリアライズしてバイナリする
+    Microsoft::WRL::ComPtr<ID3DBlob> signatureBlob = nullptr;
+    Microsoft::WRL::ComPtr<ID3DBlob> errorBlob = nullptr;
+    hr = D3D12SerializeRootSignature(&descriptionRootSignature, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, &errorBlob);
+    if (FAILED(hr))
+    {
+        Debug::Log(reinterpret_cast<char*>(errorBlob->GetBufferPointer()));
+        assert(false);
+    }
+    hr = DXCommon::GetInstance()->GetDevice()->CreateRootSignature(0, signatureBlob->GetBufferPointer(),
+        signatureBlob->GetBufferSize(), IID_PPV_ARGS(&rootSignature_));
+    assert(SUCCEEDED(hr));
+#pragma endregion
+}
+
+void GrayScale::UpdateData()
+{
+    if (data_)
+    {
+        UpdateConstantBuffer(data_, sizeof(GrayScaleData));
+    }
+}

--- a/Engine/Features/PostEffects/GrayScale.h
+++ b/Engine/Features/PostEffects/GrayScale.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Features/PostEffects/PostEffectBase.h>
+
+struct GrayScaleData
+{
+    float intensity = 1.0f; // グレースケールの強度
+
+    float padding[3] = { 0.0f, 0.0f, 0.0f }; // パディング用
+};
+
+class GrayScale : public PostEffectBase
+{
+public:
+    GrayScale() = default;
+    ~GrayScale() override = default;
+
+    void Initialize() override;
+
+    void Apply(const std::string& _input, const std::string& _output) override;
+
+    void SetData(GrayScaleData* _data);
+private:
+
+    void CreatePipelineState();
+    void CreateRootSignature();
+
+    void UpdateData();
+private:
+
+    GrayScaleData* data_; // グレースケールのデータ
+
+
+};

--- a/Engine/Resources/Shader/GrayScale.hlsl
+++ b/Engine/Resources/Shader/GrayScale.hlsl
@@ -4,6 +4,13 @@
 Texture2D<float4> gTexture : register(t0);
 SamplerState gSampler : register(s0);
 
+cbuffer gConstants : register(b0)
+{
+    float intensity; // グレースの強度
+
+    float3 padding; // パディング
+};
+
 struct PixelShaderOutput
 {
     float4 color : SV_Target0;
@@ -14,7 +21,7 @@ PixelShaderOutput main(VertexOutput _input)
     PixelShaderOutput output;
     output.color = gTexture.Sample(gSampler, _input.uv);
     float value = dot(output.color.rgb, float3(0.2125f, 0.7154f, 0.0721f));
-    output.color.rgb = float3(value, value, value);
+    output.color.rgb = lerp(output.color.rgb, float3(value, value, value), intensity);
     output.color.a = 1.0f;
     return output;
 }


### PR DESCRIPTION
- `GrayScale.cpp` にグレースケールエフェクトの初期化、適用、パイプラインステート、ルートシグネチャ、データ更新の関数を追加
- `GrayScale.h` に `GrayScaleData` 構造体を追加し、強度を指定するメンバー変数を定義
- `GrayScale.hlsl` にシェーダーの定数バッファに `intensity` 変数を追加し、色の補間処理を実装

推奨ブランチ名 : feature/gray_scale_effect