### PR TITLE
エラーハンドリングとデストラクタの追加

### DIFF
--- a/Engine/System/Audio/AudioSystem.cpp
+++ b/Engine/System/Audio/AudioSystem.cpp
@@ -40,6 +40,7 @@ std::shared_ptr<SoundInstance> AudioSystem::Load(const std::string& _filename)
     {
         Debug::Log("Error: File not found - " + _filename + "\n");
         throw std::runtime_error("Error: File not found - " + _filename);
+        return nullptr;
     }
 
     // RIFFヘッダーの読み込み
@@ -49,11 +50,13 @@ std::shared_ptr<SoundInstance> AudioSystem::Load(const std::string& _filename)
     {
         Debug::Log("Error: Not a RIFF - " + _filename + "\n");
         throw std::runtime_error("Error: Not a RIFF");
+        return nullptr;
     }
     if (strncmp(riff.type, "WAVE", 4) != 0)
     {
         Debug::Log("Error: Not a WAVE - " + _filename + "\n");
         throw std::runtime_error("Error: Not a WAVE");
+        return nullptr;
     }
 
     // フォーマットチャンクとデータチャンクを見つけるまで繰り返し
@@ -110,12 +113,14 @@ std::shared_ptr<SoundInstance> AudioSystem::Load(const std::string& _filename)
     {
         Debug::Log("Error: No format chunk found - " + _filename + "\n");
         throw std::runtime_error("Error: No format chunk found - " + _filename);
+        return nullptr;
     }
 
     if (!foundData)
     {
         Debug::Log("Error: No data chunk found - " + _filename + "\n");
         throw std::runtime_error("Error: No data chunk found - " + _filename);
+        return nullptr;
     }
 
     // データの読み込み

--- a/Engine/System/Audio/VoiceInstance.cpp
+++ b/Engine/System/Audio/VoiceInstance.cpp
@@ -28,6 +28,15 @@ VoiceInstance::VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume, f
 
 }
 
+VoiceInstance::~VoiceInstance()
+{
+    if (sourceVoice_)
+    {
+        sourceVoice_->DestroyVoice();
+        sourceVoice_ = nullptr;
+    }
+}
+
 void VoiceInstance::Play()
 {
     if (sourceVoice_)

--- a/Engine/System/Audio/VoiceInstance.h
+++ b/Engine/System/Audio/VoiceInstance.h
@@ -6,7 +6,7 @@ class VoiceInstance
 {
 public:
     VoiceInstance(IXAudio2SourceVoice* _sourceVoice, float _volume = 1.0f, float _sampleRate = 44100.0f, float _startTime = 0.0f);
-    ~VoiceInstance() = default;
+    ~VoiceInstance();
 
     /// <summary>
     /// 始めから再生


### PR DESCRIPTION
- `AudioSystem.cpp`の`Load`関数において、ファイルが見つからない場合やRIFF/WAVE形式でない場合、フォーマットチャンクやデータチャンクが見つからない場合に`nullptr`を返す処理を追加。
- `VoiceInstance.cpp`にデストラクタ`~VoiceInstance()`を追加し、`sourceVoice_`が存在する場合にそのボイスを破棄する処理を実装。
- `VoiceInstance.h`でデストラクタの宣言をデフォルトからカスタムデストラクタに変更。