### PR TITLE
UIクラスの改善，UIに親を持たせられるように

### DIFF
--- a/Engine/Features/Sprite/Sprite.cpp
+++ b/Engine/Features/Sprite/Sprite.cpp
@@ -74,6 +74,7 @@ void Sprite::Draw()
 
 void Sprite::Draw(const Vector4& _color)
 {
+    PreDraw();
     auto commandList = DXCommon::GetInstance()->GetCommandList();
     TransferData(commandList);
     colorObj_->SetColor(_color);

--- a/Engine/Features/UI/UIBase.cpp
+++ b/Engine/Features/UI/UIBase.cpp
@@ -26,6 +26,8 @@ void UIBase::Initialize(const std::string& _label)
     jsonBinder_->RegisterVariable(label_ + "_textureName", &textureName_);
     jsonBinder_->RegisterVariable(label_ + "_directoryPath", &directoryPath_);
     jsonBinder_->RegisterVariable(label_ + "_label", &label_);
+    jsonBinder_->RegisterVariable(label_ + "_Text", &textParam_);
+    jsonBinder_->RegisterVariable(label_ + "_TextOffset", &textOffset_);
 
     if (textureName_ == "")
         textureName_ = "white.png";
@@ -67,7 +69,7 @@ void UIBase::Draw()
     {
         return;
     }
-    sprite_->translate_ = position_;
+    sprite_->translate_ = GetWorldPos();
     sprite_->SetSize(size_);
     sprite_->rotate_ = rotate_;
     sprite_->SetAnchor(anchor_);
@@ -76,7 +78,7 @@ void UIBase::Draw()
 
     if (hasText_)
     {
-        textParam_.position = position_ + textOffset_;
+        textParam_.position = GetWorldPos() + textOffset_;
         textParam_.pivot = anchor_;
 
         textGenerator_.Draw(text_, textParam_);
@@ -93,8 +95,8 @@ bool UIBase::IsMousePointerInside() const
 bool UIBase::IsPointInside(const Vector2& _point) const
 {
     // アンカーを考慮した四頂点の計算
-    Vector2 leftTop = position_ - size_ * anchor_;
-    Vector2 rightBottom = position_ + size_ * (Vector2{ 1,1 } - anchor_);
+    Vector2 leftTop = GetWorldPos() - size_ * anchor_;
+    Vector2 rightBottom = GetWorldPos() + size_ * (Vector2{ 1,1 } - anchor_);
     Vector2 rightTop = { rightBottom.x, leftTop.y };
     Vector2 leftBottom = { leftTop.x, rightBottom.y };
 
@@ -106,6 +108,21 @@ bool UIBase::IsPointInside(const Vector2& _point) const
     }
 
     return false;
+}
+
+const Vector2& UIBase::GetWorldPos() const
+{
+    Vector2 pos = position_;
+    if (parent_)
+        pos +=parent_->GetWorldPos();
+
+    return pos;
+}
+
+void UIBase::SetParent(UIBase* _parent)
+{
+    if (_parent)
+        parent_ = _parent;
 }
 
 void UIBase::SetTextureNameAndLoad(const std::string& _textureName)

--- a/Engine/Features/UI/UIBase.h
+++ b/Engine/Features/UI/UIBase.h
@@ -21,6 +21,7 @@ public:
     virtual void Update() {};
     virtual void Draw();
 
+
     bool IsMousePointerInside() const;
     bool IsPointInside(const Vector2& _point) const;
 
@@ -37,6 +38,9 @@ public:
 
     const Vector2& GetPos() const { return position_; }
     void SetPos(const Vector2& _pos) { position_ = _pos; };
+
+    const Vector2& GetWorldPos() const;
+    void SetParent(UIBase* _parent);
 
     const Vector2& GetSize() const { return size_; }
     void SetSize(const Vector2& _size) { size_ = _size; };
@@ -95,5 +99,5 @@ protected:
 
     Vector2 textOffset_ = { 0,0 }; // テキストのオフセット
 
-
+    UIBase* parent_ = nullptr; // 親UI要素
 };

--- a/Engine/Features/UI/UIButton.cpp
+++ b/Engine/Features/UI/UIButton.cpp
@@ -41,14 +41,22 @@ void UIButton::Update()
     if (isTrigered_)
     {
         if (onClickStart_)
+        {
             onClickStart_(); // クリック開始時のコールバック
+
+            isClickEnd_ = true; // クリック終了フラグをリセット
+            isTrigered_ = false;
+        }
         else
             isTrigered_ = false;
     }
     else if (isClickEnd_)
     {
         if (onClickEnd_)
+        {
             onClickEnd_(); // クリック終了時のコールバック
+            isClickEnd_ = false;
+        }
         else
             isTrigered_ = false;
     }

--- a/Engine/Features/UI/UIButton.h
+++ b/Engine/Features/UI/UIButton.h
@@ -61,15 +61,15 @@ public:
         std::function<void(void)> _onClickStart,
         std::function<void(void)> _onClickEnd);
 
-    // コールバックを設定する
+    // フォーカスを得たときのコールバックを設定する
     void SetCallBackOnFocusGained(std::function<void(void)> _onFocusGained) { onFocusGained_ = _onFocusGained; }
-    // コールバックを設定する
+    // フォーカスを失ったときのコールバックを設定する
     void SetCallBackOnFocusLost(std::function<void(void)> _onFocusLost) { onFocusLost_ = _onFocusLost; }
-    // コールバックを設定する
+    // フォーカス時の更新時のコールバックを設定する
     void SetCallBackOnFocusUpdate(std::function<void(void)> _onFocusUpdate) { onFocusUpdate_ = _onFocusUpdate; }
-    // コールバックを設定する
+    // クリック開始時のコールバックを設定する (SEや視覚効果など
     void SetCallBackOnClickStart(std::function<void(void)> _onClickStart) { onClickStart_ = _onClickStart; }
-    // コールバックを設定する
+    // クリック終了時のコールバックを設定する
     void SetCallBackOnClickEnd(std::function<void(void)> _onClickEnd) { onClickEnd_ = _onClickEnd; }
 
 private:

--- a/Engine/GameEngine.vcxproj
+++ b/Engine/GameEngine.vcxproj
@@ -396,6 +396,7 @@ xcopy  /E /Y /I  "$(projectDir)Resources\Shader\" "$(solutionDir)Resources\Shade
     <ClInclude Include="Utility\ConvertString\ConvertString.h" />
     <ClInclude Include="Utility\FileDialog\FileDialog.h" />
     <ClInclude Include="Utility\StringUtils\StringUitls.h" />
+    <ClInclude Include="VoiceCallback.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Externals\DirectXTex\DirectXTex_Desktop_2022_Win10.vcxproj">

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -1037,6 +1037,9 @@
     <ClInclude Include="Features\PostEffects\GrayScale.h">
       <Filter>Features\PosttEffects</Filter>
     </ClInclude>
+    <ClInclude Include="VoiceCallback.h">
+      <Filter>System\Audio</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Resources\Shader\FullScreen.PS.hlsl">


### PR DESCRIPTION
- `Sprite::Draw` メソッドに `_color` 引数を追加し、`PreDraw()` を呼び出すように変更
- `UIBase::Initialize` メソッドに `textParam_` と `textOffset_` の登録を追加
- `UIBase::Draw` メソッドでスプライトの位置を `GetWorldPos()` で取得
- `UIBase::IsPointInside` メソッドで位置を `GetWorldPos()` で取得
- `UIBase` クラスに `GetWorldPos` と `SetParent` メソッドを追加
- `UIButton::Update` メソッドにクリック時のコールバック処理を追加
- `UIButton` クラスのコールバック設定メソッドのコメントを改善
- プロジェクトファイルに `VoiceCallback.h` を追加
- `GameEngine.vcxproj.filters` に `VoiceCallback.h` を追加