### PR TITLE
影周りの改善とマテリアル項目追加

### DIFF
--- a/Engine/Features/Light/Directional/DirectionalLight.cpp
+++ b/Engine/Features/Light/Directional/DirectionalLight.cpp
@@ -23,7 +23,8 @@ void DirectionalLightComponent::UpdateViewProjection(uint32_t shadowMapSize)
     if (!data_.castShadow) return;
 
     // シャドウマップサイズから計算値を設定
-    float halfSize = static_cast<float>(shadowMapSize) / 2.0f;
+    float sceneSize = 30.0f;
+    float halfSize = sceneSize / 2.0f;
 
     // 上方向ベクトルの設定
     Vector3 up = { 0.0f, 1.0f, 0.0f };
@@ -39,7 +40,7 @@ void DirectionalLightComponent::UpdateViewProjection(uint32_t shadowMapSize)
 
     // 射影行列を計算（平行投影）
     float nearClip = 0.1f;
-    float farClip = 1000.0f;
+    float farClip = 200.0f;
     Matrix4x4 projMat = MakeOrthographicMatrix(-halfSize, -halfSize, halfSize, halfSize, nearClip, farClip);
 
     // ビュー射影行列を設定

--- a/Engine/Features/Light/Directional/DirectionalLight.h
+++ b/Engine/Features/Light/Directional/DirectionalLight.h
@@ -32,7 +32,7 @@ public:
 
 
     void SetColor(const Vector4& color) { data_.color = color; }
-    void SetDirection(const Vector3& direction) { data_.direction = direction.Normalize(); }
+    void SetDirection(const Vector3& direction) { data_.direction = direction.Normalize(); UpdateViewProjection(0); }
     void SetIntensity(float intensity) { data_.intensity = intensity; }
     void SetCastShadow(bool castShadow) { data_.castShadow = castShadow ? 1 : 0; }
     void SetIsHalf(bool isHalf) { data_.isHalf = isHalf ? 1 : 0; }

--- a/Engine/Features/Model/Material/Material.cpp
+++ b/Engine/Features/Model/Material/Material.cpp
@@ -27,7 +27,7 @@ void Material::Initialize(const std::string& _texturepath)
     LoadTexture();
 
 }
-
+ 
 void Material::LoadTexture()
 {
 	if (texturePath_ == "")
@@ -45,9 +45,11 @@ void Material::TransferData()
 	constMap_->shininess = shiness_;
 	constMap_->enabledLighthig = enableLighting_;
     constMap_->hasTexture = hasTexture_ ? 1 : 0;
+    constMap_->envScale = envScale_;
+    constMap_->enableEnvironment = enableEnvironment_ ? 1 : 0;
 }
 
-void Material::MaterialQueueCommand(ID3D12GraphicsCommandList* _commandList, UINT _index) 
+void Material::MaterialQueueCommand(ID3D12GraphicsCommandList* _commandList, UINT _index)
 {
 	TransferData();
     _commandList->SetGraphicsRootConstantBufferView(_index, resorces_->GetGPUVirtualAddress());
@@ -97,4 +99,34 @@ void Material::AnalyzeMaterial(const aiMaterial* _material)
 		hasTexture_ = true;
 	else
 		hasTexture_ = false;
+}
+
+void Material::Imgui()
+{
+#ifdef _DEBUG
+    ImGui::PushID(this);
+
+    ImGui::ColorEdit4("Diffuse Color", &deffuseColor_.x);
+    ImGui::DragFloat("Shininess", &shiness_, 0.1f, 0.0f, 100.0f);
+    ImGui::Checkbox("Enable Lighting", &enableLighting_);
+    ImGui::Checkbox("Enable Environment", &enableEnvironment_);
+    ImGui::DragFloat("Environment Scale", &envScale_, 0.01f, 0.0f, 10.0f);
+
+    ImGui::Text("Texture Path: %s", texturePath_.c_str());
+    ImGui::SeparatorText("UV Transform");
+
+    Vector2 offset = uvTransform_.GetOffset();
+    Vector2 scale = uvTransform_.GetScale();
+    float rotation = uvTransform_.GetRotation();
+
+    ImGui::DragFloat2("UV Offset", &offset.x, 0.01f);
+    ImGui::DragFloat2("UV Scale", &scale.x, 0.01f);
+    ImGui::DragFloat("UV Rotation", &rotation, 0.01f);
+
+    uvTransform_.SetOffset(offset);
+    uvTransform_.SetScale(scale);
+    uvTransform_.SetRotation(rotation);
+
+    ImGui::PopID();
+#endif // _DEBUG
 }

--- a/Engine/Features/Model/Material/Material.h
+++ b/Engine/Features/Model/Material/Material.h
@@ -18,11 +18,6 @@ class Material
 {
 public:
 
-    /// uvTransform
-
-    float           shiness_                        = 40.0f;                //
-
-    bool            enableLighting_                 = true;                 // ライティングの有無
 
     void Initialize(const std::string& _texturepath);
 
@@ -33,13 +28,19 @@ public:
 
     void SetColor(const Vector4& _color) { deffuseColor_ = _color; }
 
+    void SetShininess(float _shininess) { shiness_ = _shininess; }
+    void SetEnableLighting(bool _enable) { enableLighting_ = _enable; }
+    void SetEnableEnvironment(bool _enable) { enableEnvironment_ = _enable; }
+    void SetEnvScale(float _scale) { envScale_ = _scale; }
 
     void TransferData();
     void MaterialQueueCommand(ID3D12GraphicsCommandList* _commandList, UINT _index);
     void TextureQueueCommand(ID3D12GraphicsCommandList* _commandList, UINT _index) const;
-    void TextureQueueCommand(ID3D12GraphicsCommandList* _commandList, UINT _index,uint32_t _textureHandle) const;
+    void TextureQueueCommand(ID3D12GraphicsCommandList* _commandList, UINT _index, uint32_t _textureHandle) const;
 
     void AnalyzeMaterial(const aiMaterial* _material);
+
+    void Imgui();
 private:
 
 
@@ -49,22 +50,32 @@ private:
     Vector4 deffuseColor_ = { 1.0f, 1.0f, 1.0f , 1.0f }; // ディフューズカラー
     bool hasTexture_ = true;
 
+    float shiness_ = 40.0f;                //
+    bool enableLighting_ = true;                 // ライティングの有無
+    float envScale_ = 0.0f;                 // 環境マッピングのスケール
+    bool enableEnvironment_ = false; // 環境マッピングの有無
+
     std::string     name_                           = {};
-    std::string     texturePath_                    = {};
-    uint32_t        textureHandle_                  = 0;
+    std::string     texturePath_ = {};
+    uint32_t        textureHandle_ = 0;
 
     struct DataForGPU
     {
         Matrix4x4       uvTransform;
+
         Vector4         deffuseColor;
+
         float           shininess;
         int32_t         enabledLighthig;
         int32_t         hasTexture;
-        float           padding;
+        float           envScale;
+
+        int32_t         enableEnvironment = false; // 環境マッピングの有無
+        float           padding[3];
     };
 
-    Microsoft::WRL::ComPtr<ID3D12Resource>          resorces_               = nullptr;
-    DataForGPU*                                     constMap_               = nullptr;;
+    Microsoft::WRL::ComPtr<ID3D12Resource>          resorces_ = nullptr;
+    DataForGPU* constMap_ = nullptr;;
 
     void LoadTexture();
 

--- a/Engine/Features/Model/Mesh/MargedMesh.h
+++ b/Engine/Features/Model/Mesh/MargedMesh.h
@@ -26,7 +26,11 @@ public:
     void Initialize(const std::vector<std::unique_ptr<Mesh>>& _meshes);
 
 
-    void QueueCommand(ID3D12GraphicsCommandList* _commandList) const;
+    void QueueCommandLocalIndex(ID3D12GraphicsCommandList* _commandList);
+
+    void QueueCommandAbsIndex(ID3D12GraphicsCommandList* _commandList);
+
+
 
     size_t GetMeshCount() const { return meshCount_; }
     size_t GetVertexCount() const { return vertexCount_; }
@@ -52,7 +56,7 @@ public:
     ID3D12Resource* GetVertexResource() { return vertexResource_.Get(); }
     ID3D12Resource* GetSkinnedVertexResource() { return skinnedVertexResource_.Get(); }
 
-    ID3D12Resource* GetIndexResource() { return indexResource_.Get(); }
+    ID3D12Resource* GetIndexResource() { return localIndexResource_.Get(); }
 
     D3D12_VERTEX_BUFFER_VIEW* GetVertexBufferView() { return &vertexBufferView_; }
     D3D12_VERTEX_BUFFER_VIEW* GetSkinnedVertexBufferView() { return &skinnedVertexBufferView_; }
@@ -83,9 +87,13 @@ private:
 
     // メッシュのインデックスデータ
     D3D12_INDEX_BUFFER_VIEW indexBufferView_ = {};
-    Microsoft::WRL::ComPtr<ID3D12Resource> indexResource_ = nullptr; // インデックスデータのリソース
-    uint32_t* iConstMap_ = nullptr; // インデックスデータの定数バッファマップ
+    // ローカルインデックス
+    Microsoft::WRL::ComPtr<ID3D12Resource> localIndexResource_ = nullptr; // インデックスデータのリソース
+    uint32_t* localIConstMap_ = nullptr; // インデックスデータの定数バッファマップ
 
+    // 絶対インデックス
+    Microsoft::WRL::ComPtr<ID3D12Resource> absIndexResource_ = nullptr; // アブソリュートインデックスのリソース
+    uint32_t* absIConstMap_ = nullptr; // アブソリュートインデックスの定数バッファマップ
 
     D3D12_VERTEX_BUFFER_VIEW skinnedVertexBufferView_ = {}; // スキンニング後の頂点データのバッファビュー
     Microsoft::WRL::ComPtr<ID3D12Resource> skinnedVertexResource_ = nullptr; // スキンニング後の頂点データのリソース

--- a/Engine/Features/Model/Model.h
+++ b/Engine/Features/Model/Model.h
@@ -39,12 +39,12 @@ public:
     void Draw(const WorldTransform& _transform, const Camera* _camera, uint32_t _textureHandle, ObjectColor* _color);
     void Draw(const WorldTransform& _transform, const Camera* _camera, ObjectColor* _color);
 
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, MargedMesh* _margedMesh = nullptr) const;
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList,uint32_t _textureHandle, MargedMesh* _margedMesh = nullptr) const;
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, const Vector4& _color, MargedMesh* _margedMesh = nullptr) const;
-    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_t _textureHandle, const Vector4& _color, MargedMesh* _margedMesh = nullptr) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, const std::vector<std::unique_ptr<Material>>& _materials, MargedMesh* _margedMesh = nullptr) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList,uint32_t _textureHandle, const std::vector<std::unique_ptr<Material>>& _materials,MargedMesh* _margedMesh = nullptr) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, const Vector4& _color, const std::vector<std::unique_ptr<Material>>& _materials,MargedMesh* _margedMesh = nullptr) const;
+    void QueueCommandAndDraw(ID3D12GraphicsCommandList* _commandList, uint32_t _textureHandle, const Vector4& _color, const std::vector<std::unique_ptr<Material>>& _materials, MargedMesh* _margedMesh = nullptr) const;
 
-    void QueueCommandForShadow(ID3D12GraphicsCommandList* _commandList) const;
+    void QueueCommandForShadow(ID3D12GraphicsCommandList* _commandList, MargedMesh* _margedMesh = nullptr) const;
 
     void QueueLightCommand(ID3D12GraphicsCommandList* _commandList, uint32_t _index) const;
 
@@ -62,6 +62,8 @@ public:
 
     Mesh* GetMeshPtr() { return mesh_[0].get(); }
     Material* GetMaterialPtr() { return material_[0].get(); }
+
+    const std::vector<std::unique_ptr<Material>>& GetMaterials() { return material_; }
 
     Vector3 GetMin(size_t _index = -1) const;
     Vector3 GetMax(size_t _index = -1) const;

--- a/Engine/Features/Model/ObjectModel.h
+++ b/Engine/Features/Model/ObjectModel.h
@@ -22,7 +22,7 @@ public:
     void Draw(const Camera* _camera);
     void Draw(const Camera* _camera ,const Vector4& _color);
     void Draw(const Camera* _camera, uint32_t _textureHandle, const Vector4& _color);
-    void DrawShadow(const Camera* _camera);
+    void DrawShadow();
 
 
     void UseQuaternion(bool _use) { useQuaternion_ = _use; }
@@ -43,7 +43,10 @@ public:
     UVTransform& GetUVTransform(uint32_t _index = 0) { return model_->GetUVTransform(_index); }
     Vector3 GetMin()const { return model_->GetMin(); }
     Vector3 GetMax()const { return model_->GetMax(); }
-    Material* GetMaterial() { return model_->GetMaterialPtr(); }
+
+    Material* GetMaterial() { return materials_[0].get(); }
+    Material* GetMaterial(size_t _index) { return materials_[_index].get(); }
+    std::vector<std::unique_ptr<Material>>& GetMaterials() { return materials_; }
 
     void SetTimeChannel(const std::string& _channelName) { timeChannel = _channelName; }
 
@@ -70,7 +73,7 @@ private:
     void InitializeCommon(); // 共通初期化
 
     WorldTransform worldTransform_;
-
+    std::vector<std::unique_ptr<Material>> materials_ = {};
     std::unique_ptr<ObjectColor> objectColor_ = nullptr;
     std::unique_ptr<AnimationController> uniqueAnimationController_ = nullptr;
     AnimationController* sharedAnimationController_ = nullptr;

--- a/Engine/Resources/Shader/PointLightShadowMap.hlsl
+++ b/Engine/Resources/Shader/PointLightShadowMap.hlsl
@@ -94,8 +94,12 @@ PSOutput PSmain(GSOutput input)
 {
     PSOutput output;
 
-    float z = input.Position.z / input.Position.w; // NDC座標のZ値を取得
-    output.data = float4(z, z, z, 1.0f);
+    float3 lightToPixel = input.WorldPos.xyz - PL.position; // ライト位置からピクセル位置へのベクトル
+    float distance = length(lightToPixel); // 距離を計算
+
+    float normalizedDistance = distance / PL.radius; // 距離を正規化 0~1
+
+    output.data = float4(normalizedDistance, normalizedDistance, normalizedDistance, 1.0f);
 
     return output;
 }

--- a/Engine/Resources/Shader/ShadowMap.hlsl
+++ b/Engine/Resources/Shader/ShadowMap.hlsl
@@ -1,10 +1,80 @@
-#include "Resources/Shader/Object3d.hlsli"
+//#include "Resources/Shader/Object3d.hlsli"
 
-
-cbuffer TransformationMatrix : register(b1)
+cbuffer TransformationMatrix : register(b0)
 {
     float4x4 World;
     float4x4 worldInverseTranspose;
+};
+
+
+struct DirectionalLight
+{
+    float4x4 lightVP;
+
+    float4 color;
+
+    float3 direction;
+    float intensity;
+
+    int isHalf;
+    int castShadow;
+    float shadowFactor;
+    float pad;
+};
+
+struct PointLight
+{
+    float4 color;
+
+    float3 position;
+    float intensity;
+
+    float radius;
+    float decay;
+    int isHalf;
+    int castShadow;
+
+    float shadowFactor;
+    float3 pad;
+
+    float4x4 lightVP[6];
+};
+
+struct SpotLight
+{
+    float4 color;
+
+    float3 position;
+    float intensity;
+
+    float3 direction;
+    float distance;
+
+    float decay;
+    float cosAngle;
+    float cosFalloutStart;
+    int isHalf;
+
+    int castShadow;
+    float shadowFactor;
+    float2 pad;
+
+    float4x4 lightVP;
+};
+static const int MAX_POINT_LIGHT = 32;
+static const int MAX_SPOT_LIGHT = 32;
+cbuffer gLightGroup : register(b1)
+{
+    DirectionalLight DL;
+    PointLight PL[MAX_POINT_LIGHT];
+    SpotLight SL[MAX_SPOT_LIGHT];
+    int numPointLight;
+    int numSpotLight;
+
+}
+struct VertexShaderOutput
+{
+    float4 position : SV_POSITION;
 };
 
 struct VertexShaderInput
@@ -24,22 +94,15 @@ VertexShaderOutput ShadowMapVS(VertexShaderInput _input)
 
     VertexShaderOutput output;
     output.position = mul(_input.position, mul(World, DL.lightVP));
-    output.texcoord = _input.texcoord;
-    output.normal = _input.normal;
-    output.worldPosition = mul(_input.position, World).xyz;
-    output.shadowPos = mul(float4(output.worldPosition, 1.0f), DL.lightVP);
-
 
     return output;
 }
-
-
 
 PixelShaderOutput ShadowMapPS(VertexShaderOutput _input)
 {
     PixelShaderOutput output;
 
-    float z = _input.shadowPos.z / _input.shadowPos.w; // NDC座標のZ値を取得
+    float z = _input.position.z / _input.position.w; // NDC座標のZ値を取得
 
     output.data = float4(z, z, z, 1.0f);
     return output;


### PR DESCRIPTION
- PSOManager::CreatePSOForDLShadowMap と CreatePSOForPLShadowMap でサンプラー設定を削除し、ルートパラメータ数を3から2に変更。
- PSOManager::GetRasterizerDesc で DepthClipEnable を追加。
- DirectionalLightComponent::UpdateViewProjection でシャドウマップサイズ計算を変更し、sceneSize を追加。
- Material クラスに環境マッピング関連のメンバー変数を追加し、TransferData で設定。Imgui 関数を追加。
- MargedMesh クラスでインデックスバッファ管理を改善し、ローカルインデックスと絶対インデックスのリソースを追加。
- Model クラスの QueueCommandAndDraw 関数を変更し、マテリアル配列を引数として受け取るように。
- ObjectModel クラスでアニメーションコントローラに基づく描画処理を改善し、マテリアル配列を使用。
- HLSL シェーダーでシャドウ計算ロジックを改善し、法線に基づくバイアスを追加。環境マッピング関連の変数を追加。
- ShadowMap.hlsl でライト構造体を追加し、ポイントライトとスポットライトの情報を整理。