### PR TITLE
エフェクトシーンのカメラの改善

### DIFF
--- a/Engine/Features/Effect/Editor/EffectEditorScene.cpp
+++ b/Engine/Features/Effect/Editor/EffectEditorScene.cpp
@@ -951,20 +951,16 @@ void EffectEditorScene::UpdateCamera()
         cameraRotationY_ += Time::GetDeltaTime<float>() * 0.5f; // 0.5 rad/sec
     }
 
-    // カメラ位置計算
     Vector3 cameraPos;
-    cameraPos.x = cameraTargetPosition_.x + cameraDistance_ * std::cosf(cameraRotationY_);
+    cameraPos.x = cameraTargetPosition_.x + cameraDistance_ * std::sinf(cameraRotationY_);
     cameraPos.y = cameraTargetPosition_.y + cameraHeight_;
-    cameraPos.z = cameraTargetPosition_.z + cameraDistance_ * std::sinf(cameraRotationY_);
-
+    cameraPos.z = cameraTargetPosition_.z + cameraDistance_ * std::cosf(cameraRotationY_);
     sceneCamera_.translate_ = cameraPos;
 
-    // カメラの向きを計算
+    // カメラの向き計算
     Vector3 direction = cameraTargetPosition_ - cameraPos;
     direction = direction.Normalize();
 
-    // Look-at行列を使用してカメラの回転を設定
-    // 簡略化のため、Y軸回転のみ設定
     sceneCamera_.rotate_.y = std::atan2f(direction.x, direction.z);
     sceneCamera_.rotate_.x = std::asinf(-direction.y);
 

--- a/Engine/Features/Effect/Editor/EffectEditorScene.h
+++ b/Engine/Features/Effect/Editor/EffectEditorScene.h
@@ -66,7 +66,7 @@ private:
     // === カメラ制御 ===
     Vector3 cameraTargetPosition_ = { 0, 0, 0 };
     float cameraDistance_ = 10.0f;
-    float cameraHeight_ = 5.0f;
+    float cameraHeight_ = 2.0f;
     float cameraRotationY_ = 0.0f;
     bool autoRotateCamera_ = false;
 
@@ -74,7 +74,7 @@ private:
     bool showGrid_ = true;
     bool showAxis_ = true;
     bool showBounds_ = false;
-    float gridSize_ = 1.0f;
+    float gridSize_ = 20.0f;
     int gridCount_ = 20;
 
     // === テンプレート・プリセット ===

--- a/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
+++ b/Engine/Features/Effect/Emitter/ParticleEmitter.cpp
@@ -411,7 +411,7 @@ void ParticleEmitter::InitJsonBinder()
     jsonBinder_->RegisterVariable("BoxOffset_Random", &initParams_.boxOffset.isRandom);
     jsonBinder_->RegisterVariable("BoxOffset_Min", &initParams_.boxOffset.minV);
     jsonBinder_->RegisterVariable("BoxOffset_Max", &initParams_.boxOffset.maxV);
-    jsonBinder_->RegisterVariable("BoxOffset_Max", &initParams_.boxOffset.value);
+    jsonBinder_->RegisterVariable("BoxOffset_Value", &initParams_.boxOffset.value);
 
     jsonBinder_->RegisterVariable("SphereOffset_Random", &initParams_.sphereOffset.isRandom);
     jsonBinder_->RegisterVariable("SphereOffset_Min", &initParams_.sphereOffset.minV);


### PR DESCRIPTION
- EffectEditorScene.cppのUpdateCamera関数で、カメラ位置計算の三角関数を修正し、カメラの動きを自然に調整
- cameraHeight_の初期値を5.0fから2.0fに変更し、カメラの高さを低く設定
- gridSize_の初期値を1.0fから20.0fに変更し、グリッドサイズを拡大
- emitterのJson設定項目を追加