### PR TITLE
MMFの導入

### DIFF
--- a/Engine/Debug/Debug.h
+++ b/Engine/Debug/Debug.h
@@ -7,3 +7,25 @@ namespace Debug {
 	void Log(const std::string& message);
 
 };
+
+// HRESULTのエラーチェックとログ出力
+#define CHECK_HR(hr, msg) \
+    if (FAILED(hr)) { \
+        Debug::Log(std::string(__FILE__) + "(" + std::to_string(__LINE__) + ") " + \
+                   __FUNCTION__ + ": " + msg + " HRESULT=0x" + \
+                   std::to_string(static_cast<unsigned long>(hr))); \
+        return nullptr; \
+    }
+// HRESULTのエラーチェックとログ出力（戻り値がない場合）
+#define CHECK_HR_VOID(hr, msg) \
+    if (FAILED(hr)) { \
+        Debug::Log(std::string(__FILE__) + "(" + std::to_string(__LINE__) + ") " + \
+                   __FUNCTION__ + ": " + msg + " HRESULT=0x" + \
+                   std::to_string(static_cast<unsigned long>(hr))); \
+        return; \
+    }
+
+// ログ出力マクロ
+#define LOG_ERROR(msg) \
+    Debug::Log(std::string(__FILE__) + "(" + std::to_string(__LINE__) + ") " + \
+               __FUNCTION__ + ": " + msg)

--- a/Engine/System/Audio/AudioSystem.h
+++ b/Engine/System/Audio/AudioSystem.h
@@ -13,6 +13,16 @@
 
 #pragma comment (lib,"xaudio2.lib")
 
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+
+#pragma comment(lib, "Mf.lib")
+#pragma comment(lib, "mfplat.lib")
+#pragma comment(lib, "Mfreadwrite.lib")
+#pragma comment(lib, "mfuuid.lib")
+
+
 class SoundInstance;
 
 class AudioSystem
@@ -32,8 +42,8 @@ public:
     float GetMasterVolume() const { return masterVolume_; }
 
     const WAVEFORMATEX& GetSoundFormat(uint32_t _soundID) const { return sounds_[_soundID].wfex; }
-    BYTE* GetBuffer(uint32_t _soundID) const { return sounds_[_soundID].pBuffer; }
-    unsigned int GetBufferSize(uint32_t _soundID) const { return sounds_[_soundID].bufferSize; }
+    const BYTE* GetBuffer(uint32_t _soundID) const { return sounds_[_soundID].mediaData.data(); }
+    size_t GetBufferSize(uint32_t _soundID) const { return sounds_[_soundID].mediaData.size(); }
 
 
 private:
@@ -41,8 +51,7 @@ private:
     struct SoundData
     {
         WAVEFORMATEX wfex;
-        BYTE* pBuffer;
-        unsigned int bufferSize;
+        std::vector<BYTE> mediaData;
         std::string path;
     };
 
@@ -62,7 +71,8 @@ private:
 
     float masterVolume_ = 1.0f;
 
-    void SoundUnLoad(SoundData* _soundData);
+
+    std::shared_ptr<SoundInstance> CreateSoundInstance(const WAVEFORMATEX& _wfex, std::vector<BYTE> _mediaData, const std::string& _path);
 
 
 private:

--- a/Engine/System/Audio/SoundInstance.cpp
+++ b/Engine/System/Audio/SoundInstance.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<VoiceInstance> SoundInstance::GenerateVoiceInstance(float _volum
 
     XAUDIO2_BUFFER buf{};
     buf.pAudioData = audioSystem_->GetBuffer(soundID_);
-    buf.AudioBytes = audioSystem_->GetBufferSize(soundID_);
+    buf.AudioBytes = static_cast<UINT32>(audioSystem_->GetBufferSize(soundID_));
     buf.PlayBegin = startSample;
     buf.PlayLength = 0; // 最後まで再生
     buf.Flags = XAUDIO2_END_OF_STREAM;
@@ -91,7 +91,7 @@ float SoundInstance::GetDuration() const
 {
     if (audioSystem_)
     {
-        unsigned int bufSize = audioSystem_->GetBufferSize(soundID_);
+        size_t bufSize = audioSystem_->GetBufferSize(soundID_);
         auto& wfex = audioSystem_->GetSoundFormat(soundID_);
 
         if (wfex.nAvgBytesPerSec > 0)


### PR DESCRIPTION
- `Debug.h`にエラーチェック用マクロ`CHECK_HR`と`CHECK_HR_VOID`を追加し、ログ出力を簡素化。
- `AudioSystem.cpp`の`Initialize`メソッドにXAudio2とMedia Foundationのエラーチェックを追加。
- `Load`メソッドをMedia Foundationを使用した音声ファイルの読み込みに変更し、エラーチェックを追加。
- `SoundUnLoad`メソッドを削除し、`CreateSoundInstance`メソッドを追加して音声データを`std::vector<BYTE>`で管理。
- `AudioSystem.h`にMedia Foundation関連のヘッダーファイルを追加し、音声データ管理方法を更新。