### PR TITLE
ポインタから共有ポインタへの変更

### DIFF
--- a/Engine/Features/UI/UIGroup.cpp
+++ b/Engine/Features/UI/UIGroup.cpp
@@ -38,19 +38,19 @@ void UIGroup::Draw()
     }
 }
 
-UIButton* UIGroup::CreateButton(const std::string& _label, const std::wstring& _text)
+std::shared_ptr<UIButton> UIGroup::CreateButton(const std::string& _label, const std::wstring& _text)
 {
     return CreateElement<UIButton>(_label, _text);
 }
 
-UISprite* UIGroup::CreateSprite(const std::string& _label, const std::wstring& _text)
+std::shared_ptr<UISprite> UIGroup::CreateSprite(const std::string& _label, const std::wstring& _text)
 {
     return CreateElement<UISprite>(_label, _text);
 }
 
-UISlider* UIGroup::CreateSlider(const std::string& _label, float _minV, float _maxV)
+std::shared_ptr<UISlider> UIGroup::CreateSlider(const std::string& _label, float _minV, float _maxV)
 {
-    UISlider* newSlider = CreateSliderInternal(_label, _minV, _maxV);
+    auto newSlider = CreateSliderInternal(_label, _minV, _maxV);
     newSlider->SetRange(_minV, _maxV);
     return newSlider;
 }
@@ -75,7 +75,7 @@ void UIGroup::RemoveElement(UIBase* _element)
         return;
 
     auto it = std::find_if(uiElements_.begin(), uiElements_.end(),
-        [_element](const std::unique_ptr<UIBase>& element) {
+        [_element](const std::shared_ptr<UIBase>& element) {
             return element.get() == _element;
         });
 
@@ -135,21 +135,20 @@ void UIGroup::LinkGrid(std::initializer_list<std::initializer_list<UISelectable*
     SetupGridNavigation(elementGrid);
 }
 
-UISlider* UIGroup::CreateSliderInternal(const std::string& _label, float _minV, float _maxV)
+std::shared_ptr<UISlider> UIGroup::CreateSliderInternal(const std::string& _label, float _minV, float _maxV)
 {
-    auto element = std::make_unique<UISlider>();
+    auto element = std::make_shared<UISlider>();
 
-    uiElements_.push_back(std::move(element));
-    UISlider* newSlider = static_cast<UISlider*>(uiElements_.back().get());
 
-    navigator_.RegisterSelectable(newSlider);
+    navigator_.RegisterSelectable(element.get());
 
-        newSlider->Initialize(_label, _minV, _maxV);
+    element->Initialize(_label, _minV, _maxV);
     /*else
         newSlider->Initialize(_label, _text);*/
         // TODO : UITextを作成
         // componentみたいにする
-    return newSlider;
+    uiElements_.push_back(element);
+    return element;
 }
 
 void UIGroup::SetupVerticalNavigation(const std::vector<UISelectable*>& _elements)

--- a/Engine/Features/UI/UIGroup.h
+++ b/Engine/Features/UI/UIGroup.h
@@ -34,17 +34,17 @@ public:
     UISelectable* GetFocused() const { return navigator_.GetFocused(); }
 
     // 要素の生成
-    UIButton* CreateButton(const std::string& _label, const std::wstring& _text = L"");
-    UISprite* CreateSprite(const std::string& _label, const std::wstring& _text = L"");
-    UISlider* CreateSlider(const std::string& _label,float _minV, float _maxV);
+    std::shared_ptr<UIButton> CreateButton(const std::string& _label, const std::wstring& _text = L"");
+    std::shared_ptr<UISprite> CreateSprite(const std::string& _label, const std::wstring& _text = L"");
+    std::shared_ptr<UISlider> CreateSlider(const std::string& _label, float _minV, float _maxV);
 
     // 任意のUI要素を追加（UISelectableを継承した要素）
     template<typename T>
-    T* CreateElement(const std::string& _label, const std::wstring& _text = L"")
+    std::shared_ptr<T> CreateElement(const std::string& _label, const std::wstring& _text = L"")
     {
         static_assert(std::is_base_of_v<UIBase, T>, "T must inherit from UIBase");
 
-        auto element = std::make_unique<T>();
+        auto element = std::make_shared<T>();
         if (_text.empty())
             element->Initialize(_label);
         else
@@ -56,8 +56,8 @@ public:
             navigator_.RegisterSelectable(element.get());
         }
 
-        uiElements_.push_back(std::move(element));
-        return static_cast<T*>(uiElements_.back().get());
+        uiElements_.push_back(element);
+        return static_cast<std::shared_ptr<T>>(element);
     }
 
     // 要素を手動で追加
@@ -74,7 +74,7 @@ public: // 静的メンバ関数
 
 private:
 
-    UISlider* CreateSliderInternal(const std::string& _label, float _minV, float _maxV);
+    std::shared_ptr<UISlider> CreateSliderInternal(const std::string& _label, float _minV, float _maxV);
 
     static void SetupVerticalNavigation(const std::vector<UISelectable*>& _elements);
     static void SetupHorizontalNavigation(const std::vector<UISelectable*>& _elements);
@@ -84,5 +84,5 @@ private:
 
     UINavigator navigator_; // UIナビゲーター
 
-    std::vector<std::unique_ptr<UIBase>> uiElements_; // UI要素のコンテナ
+    std::vector<std::shared_ptr<UIBase>> uiElements_; // UI要素のコンテナ
 };


### PR DESCRIPTION
- `UIGroup` クラスのメソッドの戻り値をポインタから `std::shared_ptr` に変更し、メモリ管理を改善。
- `CreateSliderInternal` メソッドを `std::make_shared` を使用して実装を更新。
- `AddElement` メソッドの引数を `std::shared_ptr` に変更し、要素の追加方法を更新。
- `RemoveElement` メソッド内のラムダ式を `std::shared_ptr` に対応させる。
- ヘッダーファイル `UIGroup.h` の要素生成メソッドのシグネチャを更新。
- `CreateElement` テンプレートメソッドの戻り値を `std::shared_ptr` に変更。
- `uiElements_` コンテナの型を `std::vector<std::shared_ptr<UIBase>>` に変更。