### PR TITLE
プロファイリング機能の追加とコード整理

### DIFF
--- a/Engine/Features/AudioSpectrum/AudioSpectrum.cpp
+++ b/Engine/Features/AudioSpectrum/AudioSpectrum.cpp
@@ -451,6 +451,9 @@ std::vector<float> AudioSpectrum::ComputeSpectrum(float _time)
         }
         ImGui::End();
     }
+
+
+
 #endif
 
     if (useGPU_)
@@ -480,6 +483,24 @@ std::vector<float> AudioSpectrum::ComputeSpectrum(float _time)
             clock::now() - t0).count();
     }
 
+
+
+    Debug::Log(std::format("===== profile : {} ==== \n", useGPU_ ? "GPU FFT" : "CPU FFT"));
+    if (useGPU_)
+    {
+        if (fftCS_)
+        {
+            Debug::Log(std::format("Upload  : {} us\n", fftCS_->GetUploadUs()));
+            Debug::Log(std::format("CL      : {} us\n", fftCS_->GetCLUs()));
+            Debug::Log(std::format("GPU wait: {} us\n", fftCS_->GetGPUUs()));
+            Debug::Log(std::format("Readback: {} us\n", fftCS_->GetReadbackUs()));
+            Debug::Log(std::format("Total   : {} us\n", fftCS_->GetTotalUs()));
+        }
+    }
+    else
+    {
+        Debug::Log(std::format("Total   : {} us\n", cpuTotalUs_));
+    }
     return magnitude;
 
 }

--- a/Engine/Features/AudioSpectrum/AudioSpectrum.h
+++ b/Engine/Features/AudioSpectrum/AudioSpectrum.h
@@ -52,6 +52,7 @@ public:
     // 反復的FFT
     static void IterativeFFT(std::vector<std::complex<float>>& _x);
 
+    void SetUseGPU(bool useGPU) { useGPU_ = useGPU; }
 
     std::vector<float> GetAmplitudesInRange(float minHz, float maxHz);
     void GetAmplitudesInRange(size_t begin, size_t end, std::vector<float>& out);

--- a/Engine/Features/AudioSpectrum/FFTCS.cpp
+++ b/Engine/Features/AudioSpectrum/FFTCS.cpp
@@ -51,9 +51,10 @@ void Engine::FFTCS::Initialize(uint32_t fftSize)
 void Engine::FFTCS::Execute(const std::vector<float>& input, std::vector<float>& magnitudeOut)
 {
     using clock = std::chrono::high_resolution_clock;
-    auto us = [](auto a, auto b) {
-        return std::chrono::duration_cast<std::chrono::microseconds>(b - a).count();
-    };
+    auto us = [](auto a, auto b)
+        {
+            return std::chrono::duration_cast<std::chrono::microseconds>(b - a).count();
+        };
     auto t0 = clock::now();
 
     // ハニング窓とビット反転を適用してアップロードバッファに書き込む
@@ -129,16 +130,13 @@ void Engine::FFTCS::Execute(const std::vector<float>& input, std::vector<float>&
         commandList_->SetComputeRoot32BitConstants(0, 4, consts, 0);
 
         // bitReversalIndex SRV
-        commandList_->SetComputeRootDescriptorTable(1,
-                                                    srvManager_->GetGPUSRVDescriptorHandle(srvBitRevIndex_));
+        commandList_->SetComputeRootDescriptorTable(1, srvManager_->GetGPUSRVDescriptorHandle(srvBitRevIndex_));
 
         // input UAV (u0)
-        commandList_->SetComputeRootDescriptorTable(2,
-                                                    srvManager_->GetGPUSRVDescriptorHandle(inputUav));
+        commandList_->SetComputeRootDescriptorTable(2, srvManager_->GetGPUSRVDescriptorHandle(inputUav));
 
         // output UAV (u1)
-        commandList_->SetComputeRootDescriptorTable(3,
-                                                    srvManager_->GetGPUSRVDescriptorHandle(outputUav));
+        commandList_->SetComputeRootDescriptorTable(3, srvManager_->GetGPUSRVDescriptorHandle(outputUav));
 
         commandList_->Dispatch(dispatchCount, 1, 1);
 
@@ -151,14 +149,12 @@ void Engine::FFTCS::Execute(const std::vector<float>& input, std::vector<float>&
     // bits_ が奇数 → bufferB_ が最終出力
     ID3D12Resource* finalBuffer = (bits_ % 2 == 0) ? bufferA_.Get() : bufferB_.Get();
 
-    barrier = transitionBarrier(finalBuffer,
-                                D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    barrier = transitionBarrier(finalBuffer, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
     commandList_->ResourceBarrier(1, &barrier);
 
     commandList_->CopyResource(readbackBuffer_.Get(), finalBuffer);
 
-    barrier = transitionBarrier(finalBuffer,
-                                D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    barrier = transitionBarrier(finalBuffer, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
     commandList_->ResourceBarrier(1, &barrier);
 
     commandList_->Close();

--- a/Engine/Features/WaveformDisplay/WaveformDisplay.cpp
+++ b/Engine/Features/WaveformDisplay/WaveformDisplay.cpp
@@ -264,6 +264,9 @@ void WaveformDisplay::DrawWaveform()
 {
     // データの更新済みなので描画だけ行う
 
+    if (instanceCount_ == 0)
+        return;
+
     auto commandList = DXCommon::GetInstance()->GetCommandList();
 
     commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_LINELIST);

--- a/Engine/GameEngine.vcxproj.filters
+++ b/Engine/GameEngine.vcxproj.filters
@@ -861,9 +861,11 @@
     <ClCompile Include="System\Audio\AudioEffectManager.cpp">
       <Filter>System\Audio</Filter>
     </ClCompile>
-    <ClCompile Include="Features\AudioSpectrum\FFTCS.cpp" />
     <ClCompile Include="Features\Model\InstancedObjectModel.cpp">
       <Filter>Features\Model</Filter>
+    </ClCompile>
+    <ClCompile Include="Features\AudioSpectrum\FFTCS.cpp">
+      <Filter>Features\AudioSpectrum</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- `AudioSpectrum.cpp`の`ComputeSpectrum`関数にGPU/CPUのプロファイリング情報をログ出力する機能を追加
- `AudioSpectrum.h`に`SetUseGPU`メソッドを追加
- `FFTCS.cpp`の`Execute`関数内でラムダ関数の可読性を向上させ、リソースバリア設定を整理
- `WaveformDisplay.cpp`の`DrawWaveform`関数に早期リターン条件を追加
- `GameEngine.vcxproj.filters`で`FFTCS.cpp`のフィルタを修正し、プロジェクト構造を整理