### PR TITLE
シーン遷移条件の修正

### DIFF
--- a/Engine/Features/Scene/Manager/SceneManager.cpp
+++ b/Engine/Features/Scene/Manager/SceneManager.cpp
@@ -120,7 +120,7 @@ void SceneManager::ReserveScene(const std::string& _name, std::unique_ptr<SceneD
 
     instance->sceneData_ = std::move(_sceneData);
 
-    if (instance->enableTransition_ && instance->transition_ != nullptr)
+    if (instance->enableTransition_ && !instance->isTransition_ && instance->transition_ != nullptr)
     {
         instance->transition_->Start();
         instance->isTransition_ = true;


### PR DESCRIPTION
- `SceneManager::ReserveScene` メソッド内で、シーンの遷移を開始する条件を変更
- `instance->isTransition_` が `false` の場合にのみ遷移を開始するように修正