### PR TITLE
UIの座標管理を行列ベースに移行

### DIFF
--- a/Engine/Features/Sprite/Sprite.cpp
+++ b/Engine/Features/Sprite/Sprite.cpp
@@ -198,6 +198,12 @@ void Sprite::UpdateInstanceData()
     Vector3 t = { translate_,0.0f };
     instanceData_.transform = MakeAffineMatrix(s, r, t);
 
+    // 親行列があれば右から掛ける（WorldTransform の matWorld_ *= parent_->matWorld_ 相当）
+    if (parentMatrix_ != nullptr)
+    {
+        instanceData_.transform *= *parentMatrix_;
+    }
+
     instanceData_.uvTransform = uvTransform_.GetMatrix();
 
     instanceData_.color = color_;

--- a/Engine/Features/Sprite/Sprite.h
+++ b/Engine/Features/Sprite/Sprite.h
@@ -62,6 +62,10 @@ public:
     void SetOrder(int16_t _order) { order_ = _order; }
     uint16_t GetOrder() const { return order_; }
 
+    // 親行列を設定（WorldTransform の SetParent(const Matrix4x4*) 相当）
+    // 設定後は UpdateInstanceData() で localMatrix * (*parentMatrix_) を合成する
+    void SetParent(const Matrix4x4* parentMatrix) { parentMatrix_ = parentMatrix; isDirty_ = true; }
+
     void ImGui();
 private:
 
@@ -88,6 +92,9 @@ private:
     std::vector<Batch2DRenderer::VertexData> vertexData_= {};
     Batch2DRenderer::InstanceData instanceData_ = {};
     int16_t order_ = 0;
+
+    // 親行列ポインタ（SetParent() で設定、nullptr なら単体動作）
+    const Matrix4x4* parentMatrix_ = nullptr;
 
     // 頂点データを計算する必要があるか
     bool isVertexDirty_ = true;

--- a/Engine/Features/UI/Component/UISpriteRenderComponent.cpp
+++ b/Engine/Features/UI/Component/UISpriteRenderComponent.cpp
@@ -27,14 +27,16 @@ void UISpriteRenderComponent::Initialize()
 
     sprite_ = Sprite::Create("UISpriteRenderComponent_Sprite", textureHandle_, Vector2(0.5f, 0.5f));
     sprite_->SetColor(color_);
+
+    // UIElement の worldMatrix_ を親行列として登録（ポインタで保持）
+    sprite_->SetParent(&owner_->GetWorldMatrix());
 }
 
 void UISpriteRenderComponent::Update()
 {
-    // UIElementの位置・サイズと同期
-    sprite_->translate_ = owner_->GetWorldPosition();
+    // 位置・回転は親行列（UIElement::worldMatrix_）が担うため設定不要
+    // テクスチャスケールのみ設定する
     sprite_->SetSize(owner_->GetSize());
-    sprite_->rotate_ = owner_->GetRotation();
 
     sprite_->SetOrder(owner_->GetOrder());
     sprite_->SetColor(color_);

--- a/Engine/Features/UI/Element/UIElement.cpp
+++ b/Engine/Features/UI/Element/UIElement.cpp
@@ -1,4 +1,5 @@
 #include "UIElement.h"
+#include <Math/Matrix/MatrixFunction.h>
 #include <Debug/ImGuiDebugManager.h>
 
 
@@ -10,11 +11,13 @@ UIElement::UIElement(const std::string& name, [[maybe_unused]]bool child):
     position_(50.0f, 50.0f),
     size_(100.0f, 50.0f),
     rotation_(0.0f),
+    scale_(1.0f, 1.0f),
     pivot_(0.5f, 0.5f),
     anchor_(0.5f, 0.5f),
     order_(0),
     isVisible_(true),
-    isEnabled_(true)
+    isEnabled_(true),
+    worldMatrix_(MakeIdentity4x4())
 {
 #ifdef _DEBUG
     if (child)
@@ -41,6 +44,10 @@ void UIElement::Initialize()
 
 void UIElement::Update()
 {
+    // 親より先に行列を更新（WorldTransform::UpdateData() 相当）
+    // isEnabled に関わらず実行し、子への伝播を保証する
+    UpdateMatrix();
+
     if (!isEnabled_)
         return;
 
@@ -72,23 +79,35 @@ void UIElement::Draw()
     }
 }
 
-Vector2 UIElement::GetWorldPosition() const
+void UIElement::UpdateMatrix()
 {
+    Vector2 t;
     if (parent_ == nullptr)
     {
-        return position_;
+        t = position_;
+    }
+    else
+    {
+        // 親の pivot 基準でアンカー位置を求める（UI 固有処理）
+        Vector2 anchorOffset = (anchor_ - parent_->GetPivot()) * parent_->GetSize();
+        t = anchorOffset + position_;
     }
 
-    // 親要素のサイズを取得
-    Vector2 parentSize = parent_->GetSize();
-    // アンカーオフセットを計算
-    Vector2 anchorOffset = CalculateAnchorOffset(anchor_, parentSize);
-    // 親要素のLTワールド座標を取得
-    Vector2 parentLTWorldPos = parent_->GetWorldPosition() - Vector2(parentSize.x * parent_->GetPivot().x,
-                                                                     parentSize.y * parent_->GetPivot().y);
-    // ワールド座標を計算
-    Vector2 worldPos = parentLTWorldPos + anchorOffset + position_;
-    return worldPos;
+    Vector3 s     = { scale_.x, scale_.y, 1.0f };
+    Vector3 r     = { 0.0f, 0.0f, rotation_ };
+    Vector3 trans = { t.x, t.y, 0.0f };
+    worldMatrix_  = MakeAffineMatrix(s, r, trans);
+
+    // 親行列を右から掛ける（WorldTransform の matWorld_ *= parent_->matWorld_ 相当）
+    if (parent_ != nullptr)
+    {
+        worldMatrix_ *= parent_->worldMatrix_;
+    }
+}
+
+Vector2 UIElement::GetWorldPosition() const
+{
+    return { worldMatrix_.m[3][0], worldMatrix_.m[3][1] };
 }
 
 void UIElement::SetParent(UIElement* parent)
@@ -179,7 +198,8 @@ void UIElement::DrawImGuiInspector()
         {
             ImGui::DragFloat2("Position", &position_.x, 1.0f);
             ImGui::DragFloat2("Size", &size_.x, 1.0f);
-            ImGui::DragFloat("Rotation", &rotation_, 1.0f);
+            ImGui::DragFloat2("Scale", &scale_.x, 0.01f);
+            ImGui::DragFloat("Rotation", &rotation_, 0.01f);
             ImGui::DragFloat2("Pivot", &pivot_.x, 0.01f, 0.0f, 1.0f);
             ImGui::DragFloat2("Anchor", &anchor_.x, 0.01f, 0.0f, 1.0f);
         }
@@ -262,6 +282,7 @@ void UIElement::InitializeJsonBinder(const std::string& directory)
     RegisterVariable("position", &position_);
     RegisterVariable("size", &size_);
     RegisterVariable("rotation", &rotation_);
+    RegisterVariable("scale", &scale_);
     RegisterVariable("pivot", &pivot_);
     RegisterVariable("anchor", &anchor_);
     RegisterVariable("order", &order_);

--- a/Engine/Features/UI/Element/UIElement.h
+++ b/Engine/Features/UI/Element/UIElement.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Features/UI/Component/UIComponent.h>
 #include <Math/Vector/Vector2.h>
+#include <Math/Matrix/Matrix4x4.h>
 #include <Features/Json/JsonBinder.h>
 
 #include <typeinfo>
@@ -45,6 +46,9 @@ public:
     void SetRotation(float rotation) { rotation_ = rotation; }
     float GetRotation() const { return rotation_; }
 
+    void SetScale(const Vector2& scale) { scale_ = scale; }
+    const Vector2& GetScale() const { return scale_; }
+
     void SetPivot(const Vector2& pivot) { pivot_ = pivot; }
     const Vector2& GetPivot() const { return pivot_; }
 
@@ -68,7 +72,9 @@ public:
     const std::string& GetName() const { return name_; }
 
     //------------------
-    // ワールド座標の取得
+    // 行列更新・ワールド変換
+    void UpdateMatrix();
+    const Matrix4x4& GetWorldMatrix() const { return worldMatrix_; }
     Vector2 GetWorldPosition() const;
 
     //------------------
@@ -136,8 +142,12 @@ protected:
     Vector2 position_;
     Vector2 size_;
     float rotation_; // 回転角度（ラジアン）
+    Vector2 scale_;  // スケール（デフォルト: 1, 1）
     Vector2 pivot_;
     Vector2 anchor_;
+
+    // ワールド変換行列（UpdateMatrix() で毎フレーム更新）
+    Matrix4x4 worldMatrix_ = {};
 
     uint16_t order_; // 描画順序
 


### PR DESCRIPTION
UIElement に scale_, worldMatrix_ を追加し、UpdateMatrix() でWorldTransform と同じ規約（localMatrix *= parent->matWorld_）で毎フレーム更新するよう変更。

Sprite に SetParent(const Matrix4x4*) を追加し、
UISpriteRenderComponent が UIElement::worldMatrix_ のポインタを 渡すだけで、位置・回転・スケールの親子継承が自動的に反映されるようになった。