### PR TITLE
SRVManagerとInstancedObjectModelの修正

### DIFF
--- a/Engine/Core/DXCommon/SRVManager/SRVManager.cpp
+++ b/Engine/Core/DXCommon/SRVManager/SRVManager.cpp
@@ -35,9 +35,20 @@ void SRVManager::PreDraw(ID3D12GraphicsCommandList* _commandList)
 
 uint32_t SRVManager::Allocate()
 {
+    if (!freeList_.empty())
+    {
+        uint32_t index = freeList_.back();
+        freeList_.pop_back();
+        return index;
+    }
     assert(useIndex_ < kMaxIndex_ && "SRV index overflow");
     uint32_t index = useIndex_++;
     return index;
+}
+
+void SRVManager::Free(uint32_t _index)
+{
+    freeList_.push_back(_index);
 }
 
 D3D12_CPU_DESCRIPTOR_HANDLE SRVManager::GetCPUSRVDescriptorHandle(uint32_t _index)

--- a/Engine/Core/DXCommon/SRVManager/SRVManager.h
+++ b/Engine/Core/DXCommon/SRVManager/SRVManager.h
@@ -4,6 +4,7 @@
 
 #include <d3d12.h>
 #include <wrl.h>
+#include <vector>
 
 
 namespace Engine {
@@ -20,6 +21,7 @@ public:
     void PreDraw(ID3D12GraphicsCommandList* _commandList);
 
     uint32_t Allocate();
+    void Free(uint32_t _index);
     D3D12_CPU_DESCRIPTOR_HANDLE GetCPUSRVDescriptorHandle(uint32_t _index);
     D3D12_GPU_DESCRIPTOR_HANDLE GetGPUSRVDescriptorHandle(uint32_t _index);
 
@@ -43,6 +45,7 @@ private:
     Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> descriptorHeap_ = nullptr;
 
     uint32_t useIndex_ = 0;
+    std::vector<uint32_t> freeList_ = {};
     DXCommon* dxcommon_ = nullptr;
 
 

--- a/Engine/Features/Model/INSTANCEDOBJECTMODEL.CPP
+++ b/Engine/Features/Model/INSTANCEDOBJECTMODEL.CPP
@@ -6,6 +6,14 @@
 #include <Math/Matrix/MatrixFunction.h>
 #include <Debug/Debug.h>
 
+Engine::InstancedObjectModel::~InstancedObjectModel()
+{
+    if (srvIndex_ != kInvalidIndex)
+    {
+        SRVManager::GetInstance()->Free(srvIndex_);
+    }
+}
+
 void Engine::InstancedObjectModel::Initialize(const std::string& modelPath, uint32_t maxInstances)
 {
     model_ = Model::CreateFromFile(modelPath);

--- a/Engine/Features/Model/InstancedObjectModel.h
+++ b/Engine/Features/Model/InstancedObjectModel.h
@@ -20,7 +20,7 @@ class InstancedObjectModel
 public:
 
     InstancedObjectModel() = default;
-    ~InstancedObjectModel() = default;
+    ~InstancedObjectModel();
 
     static constexpr uint32_t kDefaultMaxInstances = 1024;
 
@@ -51,7 +51,8 @@ private:
     Microsoft::WRL::ComPtr<ID3D12Resource> instanceResource_;
     InstanceData* instanceMap_ = nullptr;
 
-    uint32_t srvIndex_ = 0;
+    static constexpr uint32_t kInvalidIndex = 0xFFFFFFFF;
+    uint32_t srvIndex_ = kInvalidIndex;
     D3D12_GPU_DESCRIPTOR_HANDLE srvHandle_ = {};
 
 };


### PR DESCRIPTION
- SRVManager.cppでAllocateメソッドにfreeList_からインデックスを取得する処理を追加
- SRVManager.cppにFreeメソッドを追加し、インデックスをfreeList_に追加する機能を実装
- SRVManager.hで<vector>をインクルードし、Freeメソッドの宣言とfreeList_を追加
- InstancedObjectModel.cppにデストラクタを実装し、srvIndex_が無効でない場合にSRVManagerのFreeメソッドを呼び出す処理を追加
- InstancedObjectModel.hでデストラクタの宣言を変更し、srvIndex_の初期値をkInvalidIndexに設定